### PR TITLE
action: httprequest: set a 1 Minute timeout for all http-requests

### DIFF
--- a/internal/action/httprequest/config.go
+++ b/internal/action/httprequest/config.go
@@ -113,7 +113,7 @@ func (h *Config) Template(fn func(string) (string, error)) (action.Runner, error
 		}
 	}
 
-	return &Runner{Config: &newConfig}, nil
+	return NewRunner(&newConfig), nil
 }
 
 func (c *Config) String() string {

--- a/internal/action/httprequest/httprequest.go
+++ b/internal/action/httprequest/httprequest.go
@@ -6,14 +6,29 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/simplesurance/goordinator/internal/logfields"
 	"go.uber.org/zap"
 )
 
+const DefaultHttpClientTimeout = time.Minute
+
 // Runner executes a http request.
 type Runner struct {
 	*Config
+	client *http.Client
+}
+
+// NewRunner returns a new Runner struct.
+// The HTTPClient of the runner uses a timeout of DefaultHttpClientTimeout.
+func NewRunner(cfg *Config) *Runner {
+	return &Runner{
+		Config: cfg,
+		client: &http.Client{
+			Timeout: DefaultHttpClientTimeout,
+		},
+	}
 }
 
 func (h *Runner) String() string {
@@ -39,7 +54,7 @@ func (h *Runner) Run(ctx context.Context) error {
 		req.Header.Add(k, v)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To prevent that the httprequest action can hang forever, e.g. during shutdown,
use a custom httpClient with a timeout of 1 Minute.
This should be more then enough for sending a http-request in normal scenarios.

All actions are also retried multiple times when they fail by the event loop.