### PR TITLE
Extract additional information from github webhook events

### DIFF
--- a/dist/etc/goordinator/config.toml
+++ b/dist/etc/goordinator/config.toml
@@ -37,6 +37,7 @@ log_time_key = "time_iso8601"
 # # The following template strings are supported:
 # # - `{{ .Event.PullRequestNr }}`
 # # - `{{ .Event.PullRequestName }}`
+# # - `{{ .Event.BaseBranch }}`
 # # - `{{ .Event.Branch }}`
 # # - `{{ .Event.CommitID }}`
 # # - `{{ .Event.Repository }}`

--- a/dist/etc/goordinator/config.toml
+++ b/dist/etc/goordinator/config.toml
@@ -40,6 +40,7 @@ log_time_key = "time_iso8601"
 # # - `{{ .Event.Branch }}`
 # # - `{{ .Event.CommitID }}`
 # # - `{{ .Event.Repository }}`
+# # - `{{ .Event.RepositoryOwner }}`
 # # - `{{ .Event.EventType }}`
 # # - `{{ .Event.DeliveryID }}`
 # # - `{{ .Event.Provider }}`

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -18,6 +18,7 @@ type Event struct {
 	EventType       string
 	RepositoryOwner string
 	Repository      string
+	BaseBranch      string
 	CommitID        string
 	Branch          string
 	// PullRequestNr is 0 if it's not available
@@ -29,7 +30,7 @@ func (e *Event) String() string {
 }
 
 func (e *Event) LogFields() []zap.Field {
-	fields := make([]zap.Field, 0, 8) // cap == max. size of fields we append
+	fields := make([]zap.Field, 0, 9) // cap == max. size of fields we append
 
 	fields = append(fields, logfields.EventProvider(e.Provider))
 
@@ -45,6 +46,10 @@ func (e *Event) LogFields() []zap.Field {
 
 	if e.RepositoryOwner != "" {
 		fields = append(fields, zap.String("github.repository_owner", e.RepositoryOwner))
+	}
+
+	if e.BaseBranch != "" {
+		fields = append(fields, zap.String("github.base_branch", e.BaseBranch))
 	}
 
 	if e.CommitID != "" {

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
+	"github.com/simplesurance/goordinator/internal/logfields"
 )
 
 type Event struct {
@@ -26,7 +28,9 @@ func (e *Event) String() string {
 }
 
 func (e *Event) LogFields() []zap.Field {
-	fields := make([]zap.Field, 0, 6) // cap == max. size of fields we append
+	fields := make([]zap.Field, 0, 7) // cap == max. size of fields we append
+
+	fields = append(fields, logfields.EventProvider(e.Provider))
 
 	if e.DeliveryID != "" {
 		fields = append(fields, zap.String("github.delivery_id", e.DeliveryID))

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -14,11 +14,12 @@ type Event struct {
 
 	// Github hook fields, if the value is not available they are empty
 	// strings.
-	DeliveryID string
-	EventType  string
-	Repository string
-	CommitID   string
-	Branch     string
+	DeliveryID      string
+	EventType       string
+	RepositoryOwner string
+	Repository      string
+	CommitID        string
+	Branch          string
 	// PullRequestNr is 0 if it's not available
 	PullRequestNr int
 }
@@ -28,7 +29,7 @@ func (e *Event) String() string {
 }
 
 func (e *Event) LogFields() []zap.Field {
-	fields := make([]zap.Field, 0, 7) // cap == max. size of fields we append
+	fields := make([]zap.Field, 0, 8) // cap == max. size of fields we append
 
 	fields = append(fields, logfields.EventProvider(e.Provider))
 
@@ -40,6 +41,10 @@ func (e *Event) LogFields() []zap.Field {
 
 	if e.Repository != "" {
 		fields = append(fields, zap.String("github.repository", e.Repository))
+	}
+
+	if e.RepositoryOwner != "" {
+		fields = append(fields, zap.String("github.repository_owner", e.RepositoryOwner))
 	}
 
 	if e.CommitID != "" {

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -141,7 +141,6 @@ func extractEventInfo(ghEvent interface{}) *provider.Event {
 				result.RepositoryOwner = owner.GetLogin()
 			}
 		}
-
 	} else if v, ok := ghEvent.(repoGetter); ok {
 		if repo := v.GetRepo(); repo != nil {
 			result.Repository = repo.GetName()
@@ -168,6 +167,10 @@ func extractEventInfo(ghEvent interface{}) *provider.Event {
 				// ref in PullRequestEvent contains **only**
 				// the branch name without 'refs/heads/ prefix
 				result.Branch = head.GetRef()
+			}
+
+			if base := pr.GetBase(); base != nil {
+				result.BaseBranch = base.GetRef()
 			}
 		}
 	}

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -136,10 +136,19 @@ func extractEventInfo(ghEvent interface{}) *provider.Event {
 	if v, ok := ghEvent.(pushEventRepoGetter); ok {
 		if repo := v.GetRepo(); repo != nil {
 			result.Repository = repo.GetName()
+
+			if owner := repo.GetOwner(); owner != nil {
+				result.RepositoryOwner = owner.GetLogin()
+			}
 		}
+
 	} else if v, ok := ghEvent.(repoGetter); ok {
 		if repo := v.GetRepo(); repo != nil {
 			result.Repository = repo.GetName()
+
+			if owner := repo.GetOwner(); owner != nil {
+				result.RepositoryOwner = owner.GetLogin()
+			}
 		}
 	}
 

--- a/internal/provider/github/github_test.go
+++ b/internal/provider/github/github_test.go
@@ -27,6 +27,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 		expectedPullRequestNumber int
 		expectedCommitID          string
 		expectedRepositoryOwner   string
+		expectedBaseBranch        string
 	}
 
 	testcases := []testcase{
@@ -41,6 +42,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 			expectedPullRequestNumber: 1,
 			expectedCommitID:          "8ad9dec4298f6b8f020997373cf4fe22005f2c06",
 			expectedRepositoryOwner:   "fho",
+			expectedBaseBranch:        "main",
 		},
 	}
 
@@ -67,6 +69,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 			assert.Equal(t, tc.expectedPullRequestNumber, event.PullRequestNr)
 			assert.Equal(t, tc.expectedCommitID, event.CommitID)
 			assert.Equal(t, tc.expectedRepositoryOwner, event.RepositoryOwner)
+			assert.Equal(t, tc.expectedBaseBranch, event.BaseBranch)
 		})
 	}
 }

--- a/internal/provider/github/github_test.go
+++ b/internal/provider/github/github_test.go
@@ -26,6 +26,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 		expectedEventType         string
 		expectedPullRequestNumber int
 		expectedCommitID          string
+		expectedRepositoryOwner   string
 	}
 
 	testcases := []testcase{
@@ -39,6 +40,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 			expectedEventType:         "pull_request",
 			expectedPullRequestNumber: 1,
 			expectedCommitID:          "8ad9dec4298f6b8f020997373cf4fe22005f2c06",
+			expectedRepositoryOwner:   "fho",
 		},
 	}
 
@@ -64,6 +66,7 @@ func TestHTTPHandlerEventParsing(t *testing.T) {
 			assert.Equal(t, tc.expectedProvider, event.Provider)
 			assert.Equal(t, tc.expectedPullRequestNumber, event.PullRequestNr)
 			assert.Equal(t, tc.expectedCommitID, event.CommitID)
+			assert.Equal(t, tc.expectedRepositoryOwner, event.RepositoryOwner)
 		})
 	}
 }


### PR DESCRIPTION
```
        provider: add BaseBranch field to event struct

        Extract the BaseBranch from github webhook events and store it in the Event
        struct.

        This also makes it available for tempesting via  "{{ .BaseBranch }}" in the
        configuration file.

-------------------------------------------------------------------------------
        provider: add RepositoryOwner field to event struct

        Extract the repository owner from github webhook events and store it in the
        Event struct.

        This also makes it available for templating via  "{{ .RepositoryOwner }}" in the
        configuration file.

-------------------------------------------------------------------------------
        provider: add event_provider to event logFields

        When log messages related to an event is logged, log also the event provider
        name

```