### PR TITLE
minor fixes

### DIFF
--- a/cmd/goordinator/main.go
+++ b/cmd/goordinator/main.go
@@ -328,7 +328,7 @@ func main() {
 	)
 
 	if config.HTTPListenAddr == "" && config.HTTPSListenAddr == "" {
-		logger.Warn("https_server_listen_addr and http_server_listen_addr configuration parameters are empty, not http server is started")
+		logger.Warn("https_server_listen_addr and http_server_listen_addr configuration parameters are empty, no http server is started")
 	}
 
 	if config.HTTPListenAddr != "" {

--- a/internal/goordinator/evloop.go
+++ b/internal/goordinator/evloop.go
@@ -196,6 +196,16 @@ func (e *EvLoop) scheduleAction(ctx context.Context, event *provider.Event, acti
 				if err != nil {
 					var httpErr *httprequest.ErrorHTTPRequest
 
+					if errors.Is(err, context.Canceled) {
+						logger.Error(
+							"action cancelled",
+							logfields.Event("action_cancelled"),
+							logFieldActionResult("cancelled"),
+							zap.Error(err),
+						)
+						return
+					}
+
 					if errors.As(err, &httpErr) {
 						logger.Info(
 							"action failed",


### PR DESCRIPTION
```
        main: fix error message formulation when no http server is started

-------------------------------------------------------------------------------
        evloop: give up immediately if an action returns a context cancelled error

        If action.Run() returns a context canceled error, give up immediately executing
        the action and do not log 2x that the action was canceled.

        If this happened so far, the error was logged, the loop iteration was skipped,
        then the canceled error was received from ctx.Done() and we logged another time
        that the context was canceled and gave up.

```