### PR TITLE
retryer: reduce logging, return error on termination

### DIFF
--- a/internal/goordinator/evloop.go
+++ b/internal/goordinator/evloop.go
@@ -147,7 +147,7 @@ func (e *EvLoop) scheduleAction(ctx context.Context, event *Event, action action
 		_ = e.retryer.Run(
 			ctx,
 			action.Run,
-			append(event.LogFields, action.LogFields()...),
+			append(action.LogFields(), event.LogFields...),
 		)
 	}()
 }

--- a/internal/goordinator/retryer.go
+++ b/internal/goordinator/retryer.go
@@ -95,7 +95,7 @@ func (r *Retryer) Run(ctx context.Context, fn func(context.Context) error, logF 
 			return nil
 
 		case <-r.shutdownChan:
-			return nil
+			return errors.New("event loop terminated, action not executed successful")
 		}
 	}
 }


### PR DESCRIPTION
```
        retryer: return an error when terminating and execution did not run successfully

        When retryer.Stop() was called and a running execution was not executed
        successfully, return an error from Run() instead of nil.

-------------------------------------------------------------------------------
        retryer: reduce logging

        Reduce the logging that the retryer does.
        The caller can log the execution result instead. The caller has more context
        available for the log message and can decide when and what should be logged
        freely.
        The retryer now only logs messages with debug log level for events that the
        caller is not aware of.

-------------------------------------------------------------------------------
        evloop: fix: ensure scheduleAction() does not modify event.LogFields

        In scheduleAction() elements were appended to event.LogFields and the returned
        slice was passed to retryer.Run().

        If the event.LogFields slice has >0 capacity the underlying array is not copied.
        This can cause that a following scheduleAction() call will modify during the
        same operation the slice from a previous call.
        retryer.Run() then could log fields from a wrong execution.

        Append to the value of action.LogFields() instead of to event.LogFields.
        action.LogFields() always returns a new slice.
```