### PR TITLE
autoupdater: improve logging

### DIFF
--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -241,8 +241,10 @@ func TestSuspendAndResume(t *testing.T) {
 	require.NotNil(t, queue)
 	assert.Equal(t, queue.activeLen(), 1)
 
-	errs := autoupdater.SuspendUpdates(context.Background(), repoOwner, repo, []string{pr.Branch})
+	updatedPRs, errs := autoupdater.SuspendUpdates(context.Background(), repoOwner, repo, []string{pr.Branch})
+
 	require.Empty(t, errs)
+	assert.Contains(t, updatedPRs, pr)
 
 	assert.Equal(t, queue.activeLen(), 0)
 	assert.Equal(t, queue.suspendedLen(), 1)
@@ -293,7 +295,7 @@ func TestPushToPRBranchResumesPR(t *testing.T) {
 	assert.Equal(t, queue.activeLen(), 1)
 	assert.Equal(t, queue.suspendedLen(), 0)
 
-	errs := autoupdater.SuspendUpdates(context.Background(), repoOwner, repo, []string{pr.Branch})
+	_, errs := autoupdater.SuspendUpdates(context.Background(), repoOwner, repo, []string{pr.Branch})
 	require.Empty(t, errs)
 
 	assert.Equal(t, queue.activeLen(), 0)

--- a/internal/autoupdate/logfields.go
+++ b/internal/autoupdate/logfields.go
@@ -1,0 +1,16 @@
+package autoupdate
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/simplesurance/goordinator/internal/logfields"
+)
+
+var (
+	logEventUpdatesSuspended = logfields.Event("updates_suspended")
+	logEventUpdatesResumed   = logfields.Event("updates_resumed")
+)
+
+func logFieldReason(reason string) zap.Field {
+	return zap.String("reason", reason)
+}

--- a/internal/autoupdate/logfields.go
+++ b/internal/autoupdate/logfields.go
@@ -9,6 +9,11 @@ import (
 var (
 	logEventUpdatesSuspended = logfields.Event("updates_suspended")
 	logEventUpdatesResumed   = logfields.Event("updates_resumed")
+
+	logEventEnqeued  = logfields.Event("enqueued")
+	logEventDequeued = logfields.Event("dequeued")
+
+	logReasonPRClosed = logFieldReason("pull_request_closed")
 )
 
 func logFieldReason(reason string) zap.Field {

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -192,7 +192,7 @@ func (q *queue) Dequeue(prNumber int) (*PullRequest, error) {
 		delete(q.suspended, prNumber)
 		q.lock.Unlock()
 
-		logger.Info(
+		logger.Debug(
 			"pull request removed from suspend queue",
 			logfields.Event("pull_request_dequeued"),
 		)
@@ -214,8 +214,8 @@ func (q *queue) Dequeue(prNumber int) (*PullRequest, error) {
 
 	logger := q.logger.With(removed.LogFields...)
 
-	logger.Info(
-		"pull request removed from auto-update queue",
+	logger.Debug(
+		"pull request removed from active queue",
 		logfields.Event("pull_request_dequeued"),
 	)
 
@@ -442,6 +442,12 @@ func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 					zap.Error(err),
 				)
 			}
+
+			logger.Info(
+				"pull request dequeued for updates",
+				logEventDequeued,
+				logReasonPRClosed,
+			)
 
 			return
 		}

--- a/internal/logfields/git.go
+++ b/internal/logfields/git.go
@@ -25,3 +25,7 @@ func Commit(val string) zap.Field {
 func Branch(val string) zap.Field {
 	return zap.String("git.branch", val)
 }
+
+func CheckStatus(val string) zap.Field {
+	return zap.String("git.check_status", val)
+}


### PR DESCRIPTION
When goordinator was not running with debug log level mode it was not possible
to understand from the log why a pr was enqueued, dequeued, suspended, resumed
or moved to another base-branch queue.

Change the logging behavior to always log from the caller, after one of those operations
was done the result and the reason why it was executed