### PR TITLE
Autoupdater improve http list view

### DIFF
--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -22,8 +22,8 @@ func newHTTPRespWriter(logger *zap.Logger, resp http.ResponseWriter) *httpRespWr
 }
 
 // WriteStr writes a string to the http response write.
-// If an error happens, it is logged with info priority and false is returned.
-// If it suceeded true is returned.
+// If it is successul true is returned.
+// If it fails, the error is logged with info priority and false is returned.
 func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
 	_, err := rw.ResponseWriter.Write([]byte(str))
 	if err != nil {
@@ -35,6 +35,8 @@ func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
 }
 
 func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Request) {
+	const separator = "------------------------------------------------------------------------------"
+
 	var result strings.Builder
 	// TODO: write to resp directly instead of to strings.Builder
 
@@ -50,6 +52,7 @@ func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	var queueCnt int
 	for _, queue := range a.queues {
 		success := resp.WriteStr(fmt.Sprintf(
 			"Base: %s/%s %s\n",
@@ -76,6 +79,12 @@ func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Requ
 				"\tPR: %-4d\tAdded: %s, \t%s\n", k, pr.enqueuedSince.Format(time.RFC822), "suspended",
 			))
 		}
+
+		if queueCnt < len(a.queues)-1 {
+			result.WriteString("\n" + separator + "\n\n")
+		}
+
+		queueCnt++
 	}
 
 	resp.WriteStr(result.String())

--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -9,9 +9,36 @@ import (
 	"go.uber.org/zap"
 )
 
-func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Request) {
+type httpRespWriter struct {
+	http.ResponseWriter
+	logger *zap.Logger
+}
+
+func newHTTPRespWriter(logger *zap.Logger, resp http.ResponseWriter) *httpRespWriter {
+	return &httpRespWriter{
+		ResponseWriter: resp,
+		logger:         logger,
+	}
+}
+
+// WriteStr writes a string to the http response write.
+// If an error happens, it is logged with info priority and false is returned.
+// If it suceeded true is returned.
+func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
+	_, err := rw.ResponseWriter.Write([]byte(str))
+	if err != nil {
+		rw.logger.Info("sending http response failed", zap.Error(err))
+		return false
+	}
+
+	return true
+}
+
+func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Request) {
 	var result strings.Builder
 	// TODO: write to resp directly instead of to strings.Builder
+
+	resp := newHTTPRespWriter(a.logger, respWr)
 
 	resp.Header().Add("Content-Type", "text/plain")
 
@@ -19,24 +46,20 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 	defer a.queuesLock.Unlock()
 
 	if len(a.queues) == 0 {
-		_, err := resp.Write([]byte("no pull-requests queued for updates\n"))
-		if err != nil {
-			a.logger.Info(
-				"writing to http-response writer failed",
-				zap.Error(err),
-			)
-		}
-
+		resp.WriteStr("no pull-requests queued for updates\n")
 		return
 	}
 
 	for _, queue := range a.queues {
-		result.WriteString(fmt.Sprintf(
+		success := resp.WriteStr(fmt.Sprintf(
 			"Base: %s/%s %s\n",
 			queue.baseBranch.RepositoryOwner,
 			queue.baseBranch.Repository,
 			queue.baseBranch.Branch,
 		))
+		if !success {
+			return
+		}
 
 		var i int
 		queue.active.Foreach(func(pr *PullRequest) bool {
@@ -55,11 +78,5 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	_, err := resp.Write([]byte(result.String()))
-	if err != nil {
-		a.logger.Info(
-			"writing to http-response writer failed",
-			zap.Error(err),
-		)
-	}
+	resp.WriteStr(result.String())
 }

--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -18,6 +18,18 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 	a.queuesLock.Lock()
 	defer a.queuesLock.Unlock()
 
+	if len(a.queues) == 0 {
+		_, err := resp.Write([]byte("no pull-requests queued for updates\n"))
+		if err != nil {
+			a.logger.Info(
+				"writing to http-response writer failed",
+				zap.Error(err),
+			)
+		}
+
+		return
+	}
+
 	for _, queue := range a.queues {
 		result.WriteString(fmt.Sprintf(
 			"Base: %s/%s %s\n",

--- a/internal/autoupdate/syncstat.go
+++ b/internal/autoupdate/syncstat.go
@@ -22,6 +22,6 @@ func (s *syncStat) LogFields() []zap.Field {
 		zap.Uint("pr_sync.failures", s.Failures),
 		zap.Uint("pr_sync.enqueued", s.Enqueued),
 		zap.Uint("pr_sync.dequeued", s.Dequeued),
-		zap.Uint("pr_sync.out_of_sync", s.Seen-s.Enqueued-s.Dequeued),
+		zap.Uint("pr_sync.out_of_sync", s.Enqueued+s.Dequeued),
 	}
 }


### PR DESCRIPTION
```
        autoupdater: http list: show separator line between between base-branch queues

        Separate information for different base-branch queues more clearly with a
        separator

-------------------------------------------------------------------------------
        autoupdater: add helper to write strings to http.ResponseWriter

        add a helper struct that wraps a http.ResponseWriter and provides a method to
        write a string instead to it and logs a message on error

-------------------------------------------------------------------------------
        autoupdater: http list: show a message instead of an empty page if queues empty

        If no PRs were queued for autoupdates, the http list page was showing nothing,
        print a message instead that makes it clear that the queue is empty.

-------------------------------------------------------------------------------
        autoupdater: fix: wrong pr_sync.out_of_sync count logged

        When not a single PR was found that was out-of-sync, pr_sync.out_of_sync was the
        number of all open PRs for that information was retrieved.

        Count only prs that were enqueued/dequeued during the sync operation as
        out-of-sync

```