### PR TITLE
autoupdater: fix: negative status check for old commit suspends updates

### DIFF
--- a/internal/autoupdate/doc.go
+++ b/internal/autoupdate/doc.go
@@ -18,7 +18,7 @@
 // Per base-branch, the autoupdater updates automatically the first PR in the
 // queue with it's base branch. It serializes updating per basebranch, to avoid
 // a race between multiples pull requests that result in unnecessary CI runs and merges.
-// When updating a pull request branch with it's  base-branch is not possible,
+// When updating a pull request branch with it's base-branch is not possible,
 // a failed status check for the pull request was reported, or the PR became
 // stale updates for it are suspended.
 // This prevents that pull requests that can not be merged block the autoupdate

--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -22,8 +22,8 @@ func newHTTPRespWriter(logger *zap.Logger, resp http.ResponseWriter) *httpRespWr
 }
 
 // WriteStr writes a string to the http response write.
-// If an error happens, it is logged with info priority and false is returned.
-// If it suceeded true is returned.
+// If it is successul true is returned.
+// If it fails, the error is logged with info priority and false is returned.
 func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
 	_, err := rw.ResponseWriter.Write([]byte(str))
 	if err != nil {
@@ -35,6 +35,8 @@ func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
 }
 
 func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Request) {
+	const separator = "------------------------------------------------------------------------------"
+
 	var result strings.Builder
 	// TODO: write to resp directly instead of to strings.Builder
 
@@ -50,6 +52,7 @@ func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	var queueCnt int
 	for _, queue := range a.queues {
 		success := resp.WriteStr(fmt.Sprintf(
 			"Base: %s/%s %s\n",
@@ -76,6 +79,12 @@ func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Requ
 				"\tPR: %-4d\tAdded: %s, \t%s\n", k, pr.enqueuedSince.Format(time.RFC822), "suspended",
 			))
 		}
+
+		if queueCnt < len(a.queues)-1 {
+			result.WriteString("\n" + separator + "\n\n")
+		}
+
+		queueCnt++
 	}
 
 	resp.WriteStr(result.String())

--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -9,9 +9,36 @@ import (
 	"go.uber.org/zap"
 )
 
-func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Request) {
+type httpRespWriter struct {
+	http.ResponseWriter
+	logger *zap.Logger
+}
+
+func newHTTPRespWriter(logger *zap.Logger, resp http.ResponseWriter) *httpRespWriter {
+	return &httpRespWriter{
+		ResponseWriter: resp,
+		logger:         logger,
+	}
+}
+
+// WriteStr writes a string to the http response write.
+// If an error happens, it is logged with info priority and false is returned.
+// If it suceeded true is returned.
+func (rw *httpRespWriter) WriteStr(str string) (wasSuccessful bool) {
+	_, err := rw.ResponseWriter.Write([]byte(str))
+	if err != nil {
+		rw.logger.Info("sending http response failed", zap.Error(err))
+		return false
+	}
+
+	return true
+}
+
+func (a *Autoupdater) HTTPHandlerList(respWr http.ResponseWriter, req *http.Request) {
 	var result strings.Builder
 	// TODO: write to resp directly instead of to strings.Builder
+
+	resp := newHTTPRespWriter(a.logger, respWr)
 
 	resp.Header().Add("Content-Type", "text/plain")
 
@@ -19,24 +46,20 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 	defer a.queuesLock.Unlock()
 
 	if len(a.queues) == 0 {
-		_, err := resp.Write([]byte("no pull-requests queued for updates\n"))
-		if err != nil {
-			a.logger.Info(
-				"writing to http-response writer failed",
-				zap.Error(err),
-			)
-		}
-
+		resp.WriteStr("no pull-requests queued for updates\n")
 		return
 	}
 
 	for _, queue := range a.queues {
-		result.WriteString(fmt.Sprintf(
+		success := resp.WriteStr(fmt.Sprintf(
 			"Base: %s/%s %s\n",
 			queue.baseBranch.RepositoryOwner,
 			queue.baseBranch.Repository,
 			queue.baseBranch.Branch,
 		))
+		if !success {
+			return
+		}
 
 		var i int
 		queue.active.Foreach(func(pr *PullRequest) bool {
@@ -55,11 +78,5 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	_, err := resp.Write([]byte(result.String()))
-	if err != nil {
-		a.logger.Info(
-			"writing to http-response writer failed",
-			zap.Error(err),
-		)
-	}
+	resp.WriteStr(result.String())
 }

--- a/internal/autoupdate/httphandler.go
+++ b/internal/autoupdate/httphandler.go
@@ -18,6 +18,18 @@ func (a *Autoupdater) HTTPHandlerList(resp http.ResponseWriter, req *http.Reques
 	a.queuesLock.Lock()
 	defer a.queuesLock.Unlock()
 
+	if len(a.queues) == 0 {
+		_, err := resp.Write([]byte("no pull-requests queued for updates\n"))
+		if err != nil {
+			a.logger.Info(
+				"writing to http-response writer failed",
+				zap.Error(err),
+			)
+		}
+
+		return
+	}
+
 	for _, queue := range a.queues {
 		result.WriteString(fmt.Sprintf(
 			"Base: %s/%s %s\n",

--- a/internal/autoupdate/pull_request_specifier.go
+++ b/internal/autoupdate/pull_request_specifier.go
@@ -1,0 +1,55 @@
+package autoupdate
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/simplesurance/goordinator/internal/logfields"
+)
+
+type PRSpecifierType uint8
+
+const (
+	PRSpecifierTypeUndefined PRSpecifierType = iota
+	PullRequestNumber
+	PullRequestBranch
+)
+
+type PRSpecifier interface {
+	Type() PRSpecifierType
+	String() string
+	LogField() zap.Field
+}
+
+type PRBranch struct {
+	BranchName string
+}
+
+func (p *PRBranch) Type() PRSpecifierType {
+	return PullRequestBranch
+}
+
+func (p *PRBranch) String() string {
+	return p.BranchName
+}
+
+func (p *PRBranch) LogField() zap.Field {
+	return logfields.Branch(p.BranchName)
+}
+
+type PRNumber struct {
+	Number int
+}
+
+func (p *PRNumber) Type() PRSpecifierType {
+	return PullRequestNumber
+}
+
+func (p *PRNumber) String() string {
+	return fmt.Sprint(p.Number)
+}
+
+func (p *PRNumber) LogField() zap.Field {
+	return logfields.PullRequest(p.Number)
+}

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -86,6 +86,10 @@ func newQueue(base *BaseBranch, logger *zap.Logger, ghClient GithubClient, retry
 	return &q
 }
 
+func (q *queue) String() string {
+	return fmt.Sprintf("queue for base branch: %s", q.baseBranch.String())
+}
+
 type runningTask struct {
 	pr         int
 	cancelFunc context.CancelFunc

--- a/internal/autoupdate/syncstat.go
+++ b/internal/autoupdate/syncstat.go
@@ -22,6 +22,6 @@ func (s *syncStat) LogFields() []zap.Field {
 		zap.Uint("pr_sync.failures", s.Failures),
 		zap.Uint("pr_sync.enqueued", s.Enqueued),
 		zap.Uint("pr_sync.dequeued", s.Dequeued),
-		zap.Uint("pr_sync.out_of_sync", s.Seen-s.Enqueued-s.Dequeued),
+		zap.Uint("pr_sync.out_of_sync", s.Enqueued+s.Dequeued),
 	}
 }


### PR DESCRIPTION
```
 autoupdater: fix: negative status check for old commit suspends updates

        Github Status check webhook events contain a list of branches that contain the
        commit for that a status check is negative.
        When the event was received autoupdater suspended updates for pull-requests that
        match the given branch.

        It might be that the status check notification is for an older commit and not
        the HEAD commit of the given PR. If this happened, updates for a PR were
        suspended despite the status for the HEAD commit might be positive.

        Instead of suspending a pull-request for updates when a negative status webhook
        event was received, the autoupdater now runs the update action for all
        pull-requests that match the branch, if the pull-request is first in the queue.

        This ensures that a PR is only suspended if is uptodate and it's head commit has
        a negative status check.

        Pull-Requests that are not the first element in the queue will be kept active,
        despite a failed status check. Suspending is delayed.
        When they become the first element in the queue and the status check is still
        negative for the head commit, updating will be suspended.

-------------------------------------------------------------------------------
        autoupdate: refactor TriggerUpdateIfFirst

        - return an error that indicates if the pr was first in the queue and updates
          were triggered for it, this allows to call queue.Resume() when a synchronize
          event was received only if it the pr is not already the first element in the
          active queue
        - introduce a new interface type PRSpecifier, that is accepted by
          TriggerUpdateIfFirst(), it allows to pass a parameter that can either specify
          the pr by branch name or pull-request number, it will be used in a following
          commit

-------------------------------------------------------------------------------
        autoupdater: http list: show separator line between between base-branch queues

        Separate information for different base-branch queues more clearly with a
        separator

-------------------------------------------------------------------------------
        autoupdater: add helper to write strings to http.ResponseWriter

        add a helper struct that wraps a http.ResponseWriter and provides a method to
        write a string instead to it and logs a message on error

-------------------------------------------------------------------------------
        autoupdater: http list: show a message instead of an empty page if queues empty

        If no PRs were queued for autoupdates, the http list page was showing nothing,
        print a message instead that makes it clear that the queue is empty.

-------------------------------------------------------------------------------

        autoupdater: fix: wrong pr_sync.out_of_sync count logged

        When not a single PR was found that was out-of-sync, pr_sync.out_of_sync was the
        number of all open PRs for that information was retrieved.

        Count only prs that were enqueued/dequeued during the sync operation as
        out-of-sync

```