### PR TITLE
loglevel configuration via cfg file + small fixes

### DIFF
--- a/cmd/goordinator/main.go
+++ b/cmd/goordinator/main.go
@@ -279,6 +279,12 @@ func mustInitLogger(config *cfg.Config) {
 
 	logger = logger.Named("main")
 	zap.ReplaceGlobals(logger)
+
+	goodbye.Register(func(context.Context, os.Signal) {
+		if err := logger.Sync(); err != nil {
+			fmt.Fprintf(os.Stderr, "flushing logs failed: %s\n", err)
+		}
+	})
 }
 
 func hide(in string) string {

--- a/dist/etc/goordinator/config.toml
+++ b/dist/etc/goordinator/config.toml
@@ -18,6 +18,11 @@ log_format = "logfmt"
 # be included in log messages.
 log_time_key = "time_iso8601"
 
+# log_level controls the priority threshold for log messages.
+# All messages with the the specified or a higher priority are logged.
+# Supported values: debug, info, warn, error, panic, fatal
+log_level =  "info"
+
 # The autoupdater section configures a feature to automatically update GitHub
 # pull request branches with changes from their base branch, in a serialized
 # manner.

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -713,7 +713,9 @@ func (a *Autoupdater) processStatusEvent(ctx context.Context, logger *zap.Logger
 		for _, branch := range branches {
 			pr, err := a.TriggerUpdateIfFirstAllQueues(ctx, owner, repo, &PRBranch{BranchName: branch})
 			if err != nil {
-				if !errors.Is(err, ErrNotFound) {
+				if errors.Is(err, ErrNotFound) {
+					logger.Debug("processed status event for branch that is not queued for updates")
+				} else {
 					logger.Error("triggering  update failed", zap.Error(err))
 				}
 
@@ -731,7 +733,7 @@ func (a *Autoupdater) processStatusEvent(ctx context.Context, logger *zap.Logger
 		a.ResumeIfStatusIsSuccess(ctx, owner, repo, branches)
 
 	default:
-		logger.Debug("ignoring event with unknown or not relevant status",
+		logger.Debug("ignoring event with irrelevant or unsupported status",
 			logFieldEventIgnored,
 		)
 	}

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	GithubAPIToken            string             `toml:"github_api_token"`
 	LogFormat                 string             `toml:"log_format"`
 	LogTimeKey                string             `toml:"log_time_key"`
+	LogLevel                  string             `toml:"log_level"`
 	Autoupdater               PullRequestUpdater `toml:"autoupdater"`
 	Rules                     []*Rules           `toml:"rule"`
 }

--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -246,6 +246,10 @@ type PRIter struct {
 	owner string
 	repo  string
 
+	filterState   string
+	sortOrder     string
+	sortDirection string
+
 	unseen []*github.PullRequest
 
 	nextPage int
@@ -268,8 +272,8 @@ func (it *PRIter) Next() (*github.PullRequest, error) {
 
 	prs, resp, err := it.clt.clt.PullRequests.List(it.ctx, it.owner, it.repo, &github.PullRequestListOptions{
 		State:     "open",
-		Sort:      "created",
-		Direction: "asc",
+		Sort:      it.filterState,
+		Direction: it.sortOrder,
 		ListOptions: github.ListOptions{
 			Page:    it.nextPage,
 			PerPage: 100,
@@ -295,11 +299,14 @@ func (it *PRIter) Next() (*github.PullRequest, error) {
 // all pull requests should be returned.
 func (clt *Client) ListPullRequests(ctx context.Context, owner, repo, state, sort, sortDirection string) PRIterator { // interface is returned to make the method mockable
 	return &PRIter{
-		clt:      clt,
-		ctx:      ctx,
-		owner:    owner,
-		repo:     repo,
-		nextPage: 1,
+		clt:           clt,
+		ctx:           ctx,
+		owner:         owner,
+		repo:          repo,
+		sortOrder:     sort,
+		sortDirection: sortDirection,
+		filterState:   state,
+		nextPage:      1,
 	}
 }
 

--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -279,7 +279,6 @@ func (it *PRIter) Next() (*github.PullRequest, error) {
 		return nil, it.clt.wrapRetryableErrors(err)
 	}
 
-	fmt.Printf("pagination: next: %d, last: %d\n", resp.NextPage, resp.LastPage)
 	if resp.NextPage == 0 || resp.PrevPage+1 == resp.LastPage || len(prs) == 0 {
 		it.finished = true
 	} else {


### PR DESCRIPTION
```
    githubclt: fix: some ListPullRequests parameters had no effect

        The ListPullRequests() implementation was unfinished.
        The state, sort and sortDirection parameters had no effect, they were not used.

        Store those in the iterator and pass the parameters when querying the api.

-------------------------------------------------------------------------------
        githubclt: remove left-over debug printf message

        remove a debug fmt.Printf statement from the github client

-------------------------------------------------------------------------------
        logging: flush log buffer before termination

        Call logger.Sync() before shutdown, to ensure all messages that were logged are
        written out before terminating.

-------------------------------------------------------------------------------
        cfg: support configuring log level via configuration file

        Add a new cfg key log_level that sets the log priority.
        The commandline flag "--verbose" overwrites the value specified in the config.

-------------------------------------------------------------------------------
        autoupdate: log a debug message when no branch for a status event is found

-------------------------------------------------------------------------------
```