### PR TITLE
fix: action run in tight loop if they were retried for longer then 15min

### DIFF
--- a/internal/goordinator/retryer.go
+++ b/internal/goordinator/retryer.go
@@ -20,6 +20,7 @@ const (
 	defBackoffInitialInterval     = 5 * time.Second
 	defBackoffRandomizationFactor = 0.5
 	defBackoffMaxElapsedTime      = 0 // disabled, max retry time is controlled via ctx
+	defBackoffMaxInterval         = 30 * time.Minute
 )
 
 // Retryer executes a function repeatedly until it was successful or it's
@@ -31,6 +32,7 @@ type Retryer struct {
 	backoffInitialInterval     time.Duration
 	backoffRandomizationFactor float64
 	backoffMaxElapsedTime      time.Duration
+	backoffMaxInterval         time.Duration
 }
 
 func NewRetryer() *Retryer {
@@ -41,6 +43,7 @@ func NewRetryer() *Retryer {
 		backoffInitialInterval:     defBackoffInitialInterval,
 		backoffRandomizationFactor: defBackoffRandomizationFactor,
 		backoffMaxElapsedTime:      defBackoffMaxElapsedTime,
+		backoffMaxInterval:         defBackoffMaxInterval,
 	}
 }
 
@@ -66,6 +69,7 @@ func (r *Retryer) Run(ctx context.Context, fn func(context.Context) error, logF 
 	bo.InitialInterval = r.backoffInitialInterval
 	bo.RandomizationFactor = r.backoffRandomizationFactor
 	bo.MaxElapsedTime = r.backoffMaxElapsedTime
+	bo.MaxInterval = r.backoffMaxInterval
 
 	logger := r.logger.With(logF...)
 


### PR DESCRIPTION
```
retryer: fix: action ran in tight loop if retry did not succeed after 15min

When an action was retried unsuccessfully for more then 15min, the action was
run in a tight loop. It could consume an unreasonable amount of CPU and produce
tons of log output.

This happens because the exponential backoff timer used it's default max elapsed
time setting of 15min.
After the 15min the backofftimer returned a Stop (-1 int) constant.
The retryer did not check if Stop or a negative value was returned and set the
timer for the next retry to a negative value, which means instantly.

1.) Disable the max elapsed time in the backoff timer by setting it to 0.
2.) Check in the Retryer if Stop was returned by the back Backoff timer as
  additionally safety check. This should never happen because of 1.

-------------------------------------------------------------------------------

retryer: increase max retry interval from 1 min to 30 min

Goordinator retries failed actions by default for up to 24h.
The backoff interval timer had a max. Interval of 1min set.
Increase it to 30min, retrying every minute is Unnecessarily often with such a
big retry timeout.

-------------------------------------------------------------------------------
```