### PR TITLE
ci: use official golangci-lint github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,15 @@ jobs:
       - name: Tests
         run: go test -race ./...
 
-  check:
+  golangci:
+    name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v2
       - name: golangci-lint
-        run: docker run -v $GITHUB_WORKSPACE:/repo -w /repo golangci/golangci-lint:v1.43 golangci-lint run
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.44


### PR DESCRIPTION
```
ci: use the official golangci-lint github action

Instead of running golangci-lint via docker in CI, use the official
github-action

-------------------------------------------------------------------------------
ci: run jobs on changes of main branch, instead of master

master was renamed to main
```