### PR TITLE
autoupdater: support github check statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ Updates for the PR branch are suspended when:
 
 - the base-branch can not be merged into the PR branch because of a
   merge-conflict,
-- its GitHub check status becomes negative or
-- it became stale and its status have not changed for a longer time period.
+- a negative GitHub status or check run state is reported or
+- it became stale, when it is update, approved and no check or status state has
+  been reported for a longer
+  time period.
 
 Updates for it are resumed when:
 - the PR or its base branch changed
-- the PR's status(es) check(s) became positive.
+- the PR's check runs and/or statuses  became positive.
 
 Autoupdater is used together with [Githubs auto-merge
 feature](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -27,10 +27,9 @@ const defPeriodicTriggerInterval = 30 * time.Minute
 // autoupdate implementation.
 type GithubClient interface {
 	UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (bool, error)
-	CombinedStatus(ctx context.Context, owner, repo, ref string) (string, time.Time, error)
 	CreateIssueComment(ctx context.Context, owner, repo string, issueOrPRNr int, comment string) error
 	ListPullRequests(ctx context.Context, owner, repo, state, sort, sortDirection string) githubclt.PRIterator
-	PullRequestIsApproved(ctx context.Context, owner, repo string, prNumber int) (bool, error)
+	ReadyForMergeStatus(ctx context.Context, owner, repo string, prNumber int) (*githubclt.PRStatus, error)
 }
 
 // Retryer defines methods for running GithubClient operations repeately if
@@ -231,9 +230,9 @@ func (a *Autoupdater) eventLoop() {
 //  - Resume updates for a suspended pull request on:
 //    - PullRequestEvent synchronize for the pr branch
 //    - PushEvent for it's base-branch
-//    - StatusEvent with success state and the combined status for PullRequest is successful
+//    - StatusEvent with success state and the StatusCheckRollup is successful and ReviewDecision approved.
 //    - CheckRunEvent with a neutral, success or skipped check conclusion and
-//      the combined status for PullRequest is successful
+//      the StatusCheckRollup is successful and ReviewDecision approved.
 //    - PullRequestReviewEvent with action submitted and state approved
 //
 //  - Trigger update with base-branch on:

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -876,11 +876,11 @@ func (a *Autoupdater) processCheckRunEvent(ctx context.Context, logger *zap.Logg
 			)
 		}
 
-	case "neutral", "success", "skipped":
+	case "", "neutral", "success", "skipped":
 		a.ResumeIfStatusPositive(ctx, owner, repo, branches)
 
 	default: // stale event is ignored
-		logger.Debug("ignoring event with irrelevant or unsupported check run conclusion",
+		logger.Info("ignoring event with irrelevant or unsupported check run conclusion",
 			logEventEventIgnored,
 		)
 	}

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -814,11 +814,46 @@ func (a *Autoupdater) processCheckRunEvent(ctx context.Context, logger *zap.Logg
 
 	if len(branches) == 0 {
 		logger.Info(
-			"ignorning event, pull request or branches fields are empty",
+			"ignoring event, pull request or branches fields are empty",
 			logEventEventIgnored,
 		)
 
 		return
+	}
+
+	for _, pr := range checkRun.PullRequests {
+		baseBranch := pr.GetBase().GetRef()
+		prNumber := pr.GetNumber()
+
+		logger = logger.With(
+			logfields.BaseBranch(baseBranch),
+			logfields.PullRequest(prNumber),
+		)
+
+		bb, err := NewBaseBranch(owner, repo, baseBranch)
+		if err != nil {
+			logger.Warn(
+				"ignoring check run event for pull-request, incomplete base branch information",
+				logEventEventIgnored,
+				zap.Error(err),
+			)
+
+			err := a.SetPRStaleSinceIfNewer(ctx, bb, pr.GetNumber(), time.Now())
+			if err != nil {
+				if errors.Is(err, ErrNotFound) {
+					logger.Debug(
+						"pr not queued, can not update stale timestamp",
+						logEventEventIgnored,
+					)
+					continue
+				}
+				logger.Error(
+					"updating stale timestamp failed",
+					zap.Error(err),
+					logfields.Event("updating_stale_timestamp_failed"),
+				)
+			}
+		}
 	}
 
 	switch checkRun.GetConclusion() {
@@ -873,6 +908,15 @@ func (a *Autoupdater) processStatusEvent(ctx context.Context, logger *zap.Logger
 		)
 
 		return
+	}
+
+	notFound := a.SetPRStaleSinceIfNewerByBranch(ctx, owner, repo, branches, ev.GetUpdatedAt().Time)
+	if len(notFound) > 0 {
+		logger.Debug(
+			"no pr queued for branches, can not update stale timestamp",
+			zap.Strings("not_found_branches", notFound),
+			logEventEventIgnored,
+		)
 	}
 
 	switch ev.GetState() {
@@ -1026,6 +1070,52 @@ func (a *Autoupdater) SuspendUpdates(
 	}
 
 	return updatedPrs, errors
+}
+
+// SetPRStaleSinceIfNewerByBranch sets the staleSince timestamp of the PRs for
+// the given branch names to updatdAt, if it is newer then the current
+// staleSince timestamp.
+// The method returns a list of branch names for that no queued PR could be
+// found.
+func (a *Autoupdater) SetPRStaleSinceIfNewerByBranch(
+	ctx context.Context,
+	owner, repo string,
+	branchNames []string,
+	updatedAt time.Time,
+) (notFound []string) {
+	a.queuesLock.Lock()
+	defer a.queuesLock.Unlock()
+
+	missing := toStrSet(branchNames)
+	for baseBranch, q := range a.queues {
+		if baseBranch.Repository != repo || baseBranch.RepositoryOwner != owner {
+			continue
+		}
+
+		missing = q.SetPRStaleSinceIfNewerByBranch(branchNames, updatedAt)
+	}
+
+	return strSetToSlice(missing)
+}
+
+// SetPRStaleSinceIfNewer sets the staleSince timestamp of the PR to updatedAt,
+// if it is newer then the current staleSince timestamp.
+// If the PR is not queued for autoupdates, ErrNotFound is returned.
+func (a *Autoupdater) SetPRStaleSinceIfNewer(
+	ctx context.Context,
+	baseBranch *BaseBranch,
+	prNumber int,
+	updatedAt time.Time,
+) error {
+	a.queuesLock.Lock()
+	defer a.queuesLock.Unlock()
+
+	q, exist := a.queues[baseBranch.BranchID]
+	if !exist {
+		return ErrNotFound
+	}
+
+	return q.SetPRStaleSinceIfNewer(prNumber, updatedAt)
 }
 
 // ResumeIfStatusPositive calls ScheduleResumePRIfStatusPositive for all queued

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -627,7 +627,7 @@ func TestSuccessStatusOrCheckEventResumesPRs(t *testing.T) {
 			testName: "checkrun-neutral",
 			newResumeEventFn: func(branchNames ...string) *github_prov.Event {
 				return &github_prov.Event{
-					Event: newCheckRunEvent("success", branchNames...),
+					Event: newCheckRunEvent("neutral", branchNames...),
 				}
 			},
 		},
@@ -637,6 +637,15 @@ func TestSuccessStatusOrCheckEventResumesPRs(t *testing.T) {
 			newResumeEventFn: func(branchNames ...string) *github_prov.Event {
 				return &github_prov.Event{
 					Event: newCheckRunEvent("success", branchNames...),
+				}
+			},
+		},
+
+		{
+			testName: "checkrun-conclusion-empty",
+			newResumeEventFn: func(branchNames ...string) *github_prov.Event {
+				return &github_prov.Event{
+					Event: newCheckRunEvent("", branchNames...),
 				}
 			},
 		},

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/simplesurance/goordinator/internal/autoupdate/mocks"
@@ -606,7 +607,9 @@ func TestSuccessStatusOrCheckEventResumesPRs(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.testName, func(t *testing.T) {
-			t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t).Named(t.Name())))
+			t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t,
+				zaptest.Level(zapcore.DebugLevel),
+			).Named(t.Name()).WithOptions(zap.WithCaller(true))))
 			evChan := make(chan *github_prov.Event, 1)
 			defer close(evChan)
 
@@ -630,7 +633,7 @@ func TestSuccessStatusOrCheckEventResumesPRs(t *testing.T) {
 				}).
 				MinTimes(3)
 
-			mockCombindedStatus(ghClient, "failed", time.Now(), nil).Times(3)
+			mockCombindedStatus(ghClient, "failure", time.Now(), nil).Times(3)
 			mockSuccessfulPullRequestIsApprovedCall(ghClient, 1).AnyTimes()
 			mockSuccessfulPullRequestIsApprovedCall(ghClient, 2).AnyTimes()
 			mockSuccessfulPullRequestIsApprovedCall(ghClient, 3).AnyTimes()

--- a/internal/autoupdate/drygithubclient.go
+++ b/internal/autoupdate/drygithubclient.go
@@ -2,7 +2,6 @@ package autoupdate
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -29,8 +28,13 @@ func (c *DryGithubClient) UpdateBranch(ctx context.Context, owner, repo string, 
 	return false, nil
 }
 
-func (c *DryGithubClient) CombinedStatus(ctx context.Context, owner, repo, ref string) (string, time.Time, error) {
-	return c.clt.CombinedStatus(ctx, owner, repo, ref)
+func (c *DryGithubClient) ReadyForMergeStatus(ctx context.Context, owner, repo string, prNumber int) (*githubclt.PRStatus, error) {
+	c.logger.Info("simulated fetching ready for merge status, pr is approved, all checks successful")
+
+	return &githubclt.PRStatus{
+		ReviewDecision:         githubclt.ReviewDecisionApproved,
+		StatusCheckRollupState: githubclt.StatusStateSuccess,
+	}, nil
 }
 
 func (c *DryGithubClient) CreateIssueComment(ctx context.Context, owner, repo string, issueOrPRNr int, comment string) error {
@@ -40,8 +44,4 @@ func (c *DryGithubClient) CreateIssueComment(ctx context.Context, owner, repo st
 
 func (c *DryGithubClient) ListPullRequests(ctx context.Context, owner, repo, state, sort, sortDirection string) githubclt.PRIterator {
 	return c.clt.ListPullRequests(ctx, owner, repo, state, sort, sortDirection)
-}
-
-func (c *DryGithubClient) PullRequestIsApproved(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
-	return c.clt.PullRequestIsApproved(ctx, owner, repo, prNumber)
 }

--- a/internal/autoupdate/events_test.go
+++ b/internal/autoupdate/events_test.go
@@ -142,3 +142,23 @@ func newStatusEvent(state string, branch ...string) *github.StatusEvent {
 		},
 	}
 }
+
+func newCheckRunEvent(conclusion string, branches ...string) *github.CheckRunEvent {
+	prs := make([]*github.PullRequest, 0, len(branches))
+	for _, br := range branches {
+		prs = append(prs, newBasicPullRequest(1, "master", br))
+	}
+
+	return &github.CheckRunEvent{
+		Repo: &github.Repository{
+			Name: strPtr(repo),
+			Owner: &github.User{
+				Login: strPtr(repoOwner),
+			},
+		},
+		CheckRun: &github.CheckRun{
+			PullRequests: prs,
+			Conclusion:   &conclusion,
+		},
+	}
+}

--- a/internal/autoupdate/mocks/autoupdate.go
+++ b/internal/autoupdate/mocks/autoupdate.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	githubclt "github.com/simplesurance/goordinator/internal/githubclt"
@@ -35,22 +34,6 @@ func NewMockGithubClient(ctrl *gomock.Controller) *MockGithubClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGithubClient) EXPECT() *MockGithubClientMockRecorder {
 	return m.recorder
-}
-
-// CombinedStatus mocks base method.
-func (m *MockGithubClient) CombinedStatus(ctx context.Context, owner, repo, ref string) (string, time.Time, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CombinedStatus", ctx, owner, repo, ref)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(time.Time)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CombinedStatus indicates an expected call of CombinedStatus.
-func (mr *MockGithubClientMockRecorder) CombinedStatus(ctx, owner, repo, ref interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedStatus", reflect.TypeOf((*MockGithubClient)(nil).CombinedStatus), ctx, owner, repo, ref)
 }
 
 // CreateIssueComment mocks base method.
@@ -81,19 +64,19 @@ func (mr *MockGithubClientMockRecorder) ListPullRequests(ctx, owner, repo, state
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPullRequests", reflect.TypeOf((*MockGithubClient)(nil).ListPullRequests), ctx, owner, repo, state, sort, sortDirection)
 }
 
-// PullRequestIsApproved mocks base method.
-func (m *MockGithubClient) PullRequestIsApproved(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
+// ReadyForMergeStatus mocks base method.
+func (m *MockGithubClient) ReadyForMergeStatus(ctx context.Context, owner, repo string, prNumber int) (*githubclt.PRStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullRequestIsApproved", ctx, owner, repo, prNumber)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "ReadyForMergeStatus", ctx, owner, repo, prNumber)
+	ret0, _ := ret[0].(*githubclt.PRStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PullRequestIsApproved indicates an expected call of PullRequestIsApproved.
-func (mr *MockGithubClientMockRecorder) PullRequestIsApproved(ctx, owner, repo, prNumber interface{}) *gomock.Call {
+// ReadyForMergeStatus indicates an expected call of ReadyForMergeStatus.
+func (mr *MockGithubClientMockRecorder) ReadyForMergeStatus(ctx, owner, repo, prNumber interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullRequestIsApproved", reflect.TypeOf((*MockGithubClient)(nil).PullRequestIsApproved), ctx, owner, repo, prNumber)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadyForMergeStatus", reflect.TypeOf((*MockGithubClient)(nil).ReadyForMergeStatus), ctx, owner, repo, prNumber)
 }
 
 // UpdateBranch mocks base method.

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -660,7 +660,7 @@ func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 			logfields.Event("pr_ready_to_merge"),
 		)
 
-	case githubclt.StatusStatePending, githubclt.StatusStateExpected:
+	case "", githubclt.StatusStatePending, githubclt.StatusStateExpected:
 		logger.Info(
 			"pull request is uptodate, approved and status checks are pending",
 			logfields.Event("pr_status_pending"),
@@ -836,7 +836,7 @@ func (q *queue) resumeIfPRMergeStatusPositive(ctx context.Context, logger *zap.L
 	}
 
 	switch status.StatusCheckRollupState {
-	case githubclt.StatusStateExpected, githubclt.StatusStatePending, githubclt.StatusStateSuccess:
+	case "", githubclt.StatusStateExpected, githubclt.StatusStatePending, githubclt.StatusStateSuccess:
 		if err := q.Resume(pr.Number); err != nil {
 			return fmt.Errorf("resuming updates failed: %w", err)
 		}

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -683,7 +683,7 @@ func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 			"updates suspended, status check is negative",
 			logFieldReason("status_check_negative"),
 			logEventUpdatesSuspended,
-			logfields.CheckStatus(state),
+			logfields.StatusState(state),
 			zap.Error(err),
 		)
 
@@ -707,7 +707,7 @@ func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 			"updates suspended, status check value is invalid",
 			logFieldReason("status_check_invalid"),
 			logEventUpdatesSuspended,
-			logfields.CheckStatus(state),
+			logfields.StatusState(state),
 			zap.Error(err),
 		)
 	}

--- a/internal/autoupdate/queue_test.go
+++ b/internal/autoupdate/queue_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/simplesurance/goordinator/internal/autoupdate/mocks"
+	"github.com/simplesurance/goordinator/internal/githubclt"
 	"github.com/simplesurance/goordinator/internal/goordinator"
 )
 
@@ -30,7 +31,10 @@ func TestUpdatePR_DoesNotCallBaseBranchUpdateIfPRIsNotApproved(t *testing.T) {
 	_, added := q.active.EnqueueIfNotExist(pr.Number, pr)
 	require.True(t, added)
 
-	mockPullRequestIsApprovedCall(ghClient, pr.Number, false).Times(1)
+	mockReadyForMergeStatus(
+		ghClient, pr.Number,
+		githubclt.ReviewDecisionChangesRequested, githubclt.StatusStatePending,
+	).AnyTimes()
 	ghClient.EXPECT().UpdateBranch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	q.updatePR(context.Background(), pr)

--- a/internal/autoupdate/set.go
+++ b/internal/autoupdate/set.go
@@ -1,0 +1,21 @@
+package autoupdate
+
+func toStrSet(sl []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(sl))
+
+	for _, elem := range sl {
+		result[elem] = struct{}{}
+	}
+
+	return result
+}
+
+func strSetToSlice(m map[string]struct{}) []string {
+	res := make([]string, 0, len(m))
+
+	for k := range m {
+		res = append(res, k)
+	}
+
+	return res
+}

--- a/internal/githubclt/client_test.go
+++ b/internal/githubclt/client_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/shurcooL/githubv4"
 	"github.com/simplesurance/goordinator/internal/goorderr"
+
+	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/internal/githubclt/client_test.go
+++ b/internal/githubclt/client_test.go
@@ -1,0 +1,38 @@
+package githubclt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/simplesurance/goordinator/internal/goorderr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestWrapRetryableErrorsGraphql(t *testing.T) {
+	t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t).Named(t.Name())))
+
+	// is the same then in vendor/github.com/shurcooL/graphql/graphql.go do()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	clt := Client{
+		logger:     zap.L(),
+		graphQLClt: githubv4.NewEnterpriseClient(srv.URL, srv.Client()),
+	}
+
+	s, err := clt.ReadyForMergeStatus(context.Background(), "test", "test", 123)
+	require.Error(t, err)
+	assert.Nil(t, s)
+
+	var retryableErr *goorderr.RetryableError
+	assert.ErrorAs(t, err, &retryableErr)
+}

--- a/internal/logfields/git.go
+++ b/internal/logfields/git.go
@@ -14,6 +14,26 @@ func RepositoryOwner(val string) zap.Field {
 	return zap.String("github.repository_owner", val)
 }
 
+func StatusState(val string) zap.Field {
+	return zap.String("github.status_state", val)
+}
+
+func ReviewDecision(val string) zap.Field {
+	return zap.String("github.review_decision", val)
+}
+
+func StatusCheckRollupState(val string) zap.Field {
+	return zap.String("github.status_check_rollup_state", val)
+}
+
+func CheckConclusion(val string) zap.Field {
+	return zap.String("github.check_conclusion", val)
+}
+
+func CheckStatus(val string) zap.Field {
+	return zap.String("github.check_status", val)
+}
+
 func BaseBranch(val string) zap.Field {
 	return zap.String("git.base_branch", val)
 }
@@ -24,16 +44,4 @@ func Commit(val string) zap.Field {
 
 func Branch(val string) zap.Field {
 	return zap.String("git.branch", val)
-}
-
-func StatusState(val string) zap.Field {
-	return zap.String("git.status_state", val)
-}
-
-func CheckConclusion(val string) zap.Field {
-	return zap.String("git.check_conclusion", val)
-}
-
-func CheckStatus(val string) zap.Field {
-	return zap.String("git.check_status", val)
 }

--- a/internal/logfields/git.go
+++ b/internal/logfields/git.go
@@ -26,6 +26,14 @@ func Branch(val string) zap.Field {
 	return zap.String("git.branch", val)
 }
 
+func StatusState(val string) zap.Field {
+	return zap.String("git.status_state", val)
+}
+
+func CheckConclusion(val string) zap.Field {
+	return zap.String("git.check_conclusion", val)
+}
+
 func CheckStatus(val string) zap.Field {
 	return zap.String("git.check_status", val)
 }


### PR DESCRIPTION
This PR adds support to the autoupdater for Github Checks.
The Autoupdater reacts on github Check Run webhook events, to suspend and resume PRs.
It also considers the status of check runs when running update action.

The combined status and check state is queried via GraphQL [^1].

See commit messages for more details.

[^1]: https://docs.github.com/en/graphql/reference/objects#statuscheckrollup
