### PR TITLE
rules/templating: add queryescape function

### DIFF
--- a/dist/etc/goordinator/config.toml
+++ b/dist/etc/goordinator/config.toml
@@ -78,6 +78,9 @@ autoupdater.http_endpoint = "/autoupdater"
  # - `{{ .Event.EventType }}`
  # - `{{ .Event.DeliveryID }}`
  # - `{{ .Event.Provider }}`
+ # The following template functions can be used:
+ # - `{{ queryescape "a&b" }}
+ #   Escapes a string so it can be safely placed inside a URL query.
   [[rule.action]]
    # The "httprequest" action sends a http-request. :-)
    action = "httprequest"

--- a/internal/goordinator/rule_test.go
+++ b/internal/goordinator/rule_test.go
@@ -1,0 +1,15 @@
+package goordinator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateQueryEscape(t *testing.T) {
+	templFunc := templateFunc(&Event{})
+	res, err := templFunc(`{{ queryescape "a&b+c" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "a%26b%2Bc", res)
+}


### PR DESCRIPTION
In the rule.action fields of the goordinator config, strings can now be
escaped for url query parameters by calling the queryescape template function.

This can be useful when fields from the event should be used as parameters in a
trigger URL but contain characters that must be escaped in urls.

The queryescape template functions calls the url.QueryEscape function from the
Golang stdlib.