### PR TITLE
rule: rename Template* functions to Render*

### DIFF
--- a/internal/goordinator/action/github/update_config.go
+++ b/internal/goordinator/action/github/update_config.go
@@ -26,7 +26,7 @@ func NewUpdateBranchConfig(clt *githubclt.Client) *UpdateBranchConfig {
 	}
 }
 
-func (c *UpdateBranchConfig) Template(ev action.Event, _ func(string) (string, error)) (action.Runner, error) {
+func (c *UpdateBranchConfig) Render(ev action.Event, _ func(string) (string, error)) (action.Runner, error) {
 	if ev.GetRepository() == "" {
 		return nil, errors.New("repository for event is unknown")
 	}

--- a/internal/goordinator/action/httprequest/config.go
+++ b/internal/goordinator/action/httprequest/config.go
@@ -88,27 +88,27 @@ func NewConfigFromMap(m map[string]interface{}) (*Config, error) {
 
 }
 
-// Template runs the fn callback on all configuration options that can contain
-// template strings.  fn must replace the template strings.
+// Render runs renderFunc on all configuration options that can contain
+// template strings. renderFunc must replace all template strings.
 // It returns an executable action that uses the templated config.
-func (c *Config) Template(_ action.Event, fn func(string) (string, error)) (action.Runner, error) {
+func (c *Config) Render(_ action.Event, renderFunc func(string) (string, error)) (action.Runner, error) {
 	var err error
 	newConfig := *c
 
-	newConfig.url, err = fn(newConfig.url)
+	newConfig.url, err = renderFunc(newConfig.url)
 	if err != nil {
 		return nil, fmt.Errorf("templating url failed: %w", err)
 	}
 
 	if newConfig.data != "" {
-		newConfig.data, err = fn(newConfig.data)
+		newConfig.data, err = renderFunc(newConfig.data)
 		if err != nil {
 			return nil, fmt.Errorf("templating data failed: %w", err)
 		}
 	}
 
 	for k, v := range c.headers {
-		c.headers[k], err = fn(v)
+		c.headers[k], err = renderFunc(v)
 		if err != nil {
 			return nil, fmt.Errorf("templating header failed: %w", err)
 		}

--- a/internal/goordinator/rule.go
+++ b/internal/goordinator/rule.go
@@ -22,9 +22,9 @@ import (
 
 // ActionConfig is an interface for an action that is executed as part of a Rule.
 type ActionConfig interface {
-	// Template runs templateFn for all configuration options of the action
-	// that should be templated and returns a runnable action.
-	Template(event action.Event, templateFn func(string) (string, error)) (action.Runner, error)
+	// Render runs renderFunc for all configuration options of the
+	// action that are templated and returns a runnable action.
+	Render(event action.Event, renderFunc func(string) (string, error)) (action.Runner, error)
 	// String returns a short representation of the ActionConfig
 	String() string
 	// String returns a formatted detailed description.
@@ -141,7 +141,7 @@ var templateFuncs = template.FuncMap{
 	"queryescape": url.QueryEscape,
 }
 
-func templateFunc(event *Event) func(in string) (string, error) {
+func renderFunc(event *Event) func(in string) (string, error) {
 	return func(text string) (string, error) {
 		templ, err := template.New("action").Funcs(templateFuncs).Parse(text)
 		if err != nil {
@@ -168,7 +168,7 @@ func (r *Rule) TemplateActions(ctx context.Context, event *Event) ([]action.Runn
 	result := make([]action.Runner, 0, len(r.actions))
 
 	for _, actionDef := range r.actions {
-		runner, err := actionDef.Template(event, templateFunc(event))
+		runner, err := actionDef.Render(event, renderFunc(event))
 		if err != nil {
 			return nil, fmt.Errorf("templating action definition %q failed: %w", actionDef, err)
 		}

--- a/internal/goordinator/rule_test.go
+++ b/internal/goordinator/rule_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTemplateQueryEscape(t *testing.T) {
-	templFunc := templateFunc(&Event{})
+	templFunc := renderFunc(&Event{})
 	res, err := templFunc(`{{ queryescape "a&b+c" }}`)
 	require.NoError(t, err)
 	assert.Equal(t, "a%26b%2Bc", res)


### PR DESCRIPTION
"to template" is the wrong term for describing combining a template and data to
generate a output.
Rename:
- ActionConfig.Template to ActionConfig.Render
- rule.templateFunc to rule.renderFunc