### PR TITLE
autoupdate/base-branch-change: clarify log message when PR is not queued

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -641,7 +641,13 @@ func (a *Autoupdater) processPullRequestEvent(ctx context.Context, logger *zap.L
 		}
 
 		if err := a.ChangeBaseBranch(ctx, oldBaseBranch, bb, prNumber); err != nil {
-			logError(logger, "changing base branch failed", err)
+			if errors.Is(err, ErrNotFound) || errors.Is(err, ErrAlreadyExists) {
+				logger.Debug("changing base branch for pr failed failed, pr not qeueud",
+					zap.Error(err))
+				return
+			}
+
+			logger.Error("changing base branch for pr failed", zap.Error(err))
 			return
 		}
 


### PR DESCRIPTION
When the base branch for a PR is changed that is not queued for update,
"changing base branch failed" was logged.
If the PR is not queued, log the message only with debug instead of info
priority and add the information to the message that the PR is not queued.