### PR TITLE
autoupdater: add testcase + correct debug log message

### DIFF
--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -522,7 +522,7 @@ func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 		return
 	}
 
-	logger.Debug("pr is approved and status checks are successful")
+	logger.Debug("pr is approved")
 
 	baseBranchUpdateErr := q.retryer.Run(ctx, func(ctx context.Context) error {
 		var err error


### PR DESCRIPTION
```
autoupdater/tests: add TestUpdatesAreResumeIfTestsFailAndBaseIsUpdated

Add a testcase that checks if updating for a PR is resumed despite it has a
negative check status.

-------------------------------------------------------------------------------
autoupdater: fix: wrong information in debug message

When the updatePR action was running, the PR was approved but it's check result
was negative, a debug message was logged stating wrongly that the status checks
are successful.

Correct the debug message, check status can be anything at that point.
```