### PR TITLE
autoupdater/html: fix spelling issue & rename "Enqueued At" row

### DIFF
--- a/internal/autoupdate/pages/templates/list.html.tmpl
+++ b/internal/autoupdate/pages/templates/list.html.tmpl
@@ -72,7 +72,7 @@
                 <th>Rank</th>
                 <th>Pull Request</th>
                 <th>Author</th>
-                <th>Enqueued At</th>
+                <th>Ready for Updates Since</th>
                 <th>Status</th>
               </tr>
                 {{ range $i, $pr := $queue.ActivePRs }}
@@ -97,7 +97,7 @@
                     <a href="{{ $pr.Link }} ">{{ $pr.Title }} (#{{ $pr.Number }})</a>
                   </td>
                   <td>{{ $pr.Author}}</td>
-                  <td>{{ $pr.EnqueuedSince.Format "2006-01-02 15:04:05 MST" }}</td>
+                  <td></td>
                   <td class="td_status_suspended">Suspended</td>
                 </tr>
               {{ end }}

--- a/internal/autoupdate/pages/templates/list.html.tmpl
+++ b/internal/autoupdate/pages/templates/list.html.tmpl
@@ -31,7 +31,7 @@
                 disabled
               {{ end }}
               <li>
-                MonitoredRepositories:
+                Monitored Repositories:
                 <ul>
                   {{ range .MonitoredRepositories }}
                     <li>
@@ -118,23 +118,24 @@
         </header>
 
         <p>
-          The autoupdater keeps pull requests uptodate with their base branch.
+          The autoupdater keeps pull requests up to date with their base branch.
         </p>
 
         <p>
           A pull request is enqueued for autoupdates when auto_merge for the PR
-          is enabled or it is marked with a configuration label.<br>
-          The first active pull request in each queue is kept uptodate with its
-          base-branch. If the base branch changes, the base branch is merged into
-          the pull request branch.<br>
+          is enabled or it is marked with a configurable label.<br>
+          The first pull request in each queue has the active status and is kept
+          up to date with its base-branch.
+          If the base branch changes, the base branch is merged into the pull
+          request branch.<br>
           Other pull requests are enqueued for being kept uptodate.
         </p>
 
         <p>
           If a base-branch can not be merged into a pull request branch, a
           negative status check for a PR was reported, it is not approved or it
-          become stale, updates for the PR are suspended.<br>
-          When the branch of the pull request or it base branch changes or its
+          became stale, updates for the PR are suspended.<br>
+          When the branch of the pull request or its base branch changes or its
           combined check status is not negative anymore it is enqueued again for
           being kept up to date.
         </p>


### PR DESCRIPTION
```
autoupdater/html: fix: spelling issues

-------------------------------------------------------------------------------
autoupdater/html: rename "Enqueued At" table column

Rename the "Enqueued At" table column to "Ready for Updates Since".

"Enqueued at" was confusing, it could mean the time since when the PR was
scheduled for autoupdates by e.g. enabling auto-merge.
It is the timestamp when the PR was enqueued the last time in the active queue.

-------------------------------------------------------------------------------
```