### PR TITLE
ci: update tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.49

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - goimports
@@ -13,11 +12,9 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - vet
 
 linters-settings:

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -215,33 +215,39 @@ func (a *Autoupdater) eventLoop() {
 //
 // The following actions are triggered on events:
 //
-//  - Enqueue a pull request on:
-//    - PullRequestEvent auto_merge_enabled
-//    - PullRequestEvent labeled
+// Enqueue a pull request on:
 //
-//  - Dequeue a pull request on:
-//    - PullRequestEvent closed
-//    - PullRequestEvent auto_merge_disabled
-//    - PullRequestEvent unlabeled
+//   - PullRequestEvent auto_merge_enabled
+//   - PullRequestEvent labeled
 //
-//  - Move a pull request to another base branch queue on:
-//    - PullRequestEvent edited and Base object is set
+// Dequeue a pull request on
 //
-//  - Resume updates for a suspended pull request on:
-//    - PullRequestEvent synchronize for the pr branch
-//    - PushEvent for it's base-branch
-//    - StatusEvent with success state and the StatusCheckRollup is successful and ReviewDecision approved.
-//    - CheckRunEvent with a neutral, success or skipped check conclusion and
-//      the StatusCheckRollup is successful and ReviewDecision approved.
-//    - PullRequestReviewEvent with action submitted and state approved
+//   - PullRequestEvent closed
+//   - PullRequestEvent auto_merge_disabled
+//   - PullRequestEvent unlabeled
 //
-//  - Trigger update with base-branch on:
-//    - PushEvent for a base branch
-//    - (updates for pull request branches on git-push are triggered via
-//       PullRequest synchronize events)
-//    - StatusEvent with error or failure state
-//    - CheckRunEvent with cancelled, failure, timed_out or action_required
-//      conclusion
+// Move a pull request to another base branch queue on:
+//
+//   - PullRequestEvent edited and Base object is set
+//
+// Resume updates for a suspended pull request on:
+//
+//   - PullRequestEvent synchronize for the pr branch
+//   - PushEvent for it's base-branch
+//   - StatusEvent with success state and the StatusCheckRollup is successful
+//     and ReviewDecision approved.
+//   - CheckRunEvent with a neutral, success or skipped check conclusion and
+//     the StatusCheckRollup is successful and ReviewDecision approved.
+//   - PullRequestReviewEvent with action submitted and state approved
+//
+// Trigger update with base-branch on:
+//
+//   - PushEvent for a base branch
+//   - (updates for pull request branches on git-push are triggered via
+//     PullRequest synchronize events)
+//   - StatusEvent with error or failure state
+//   - CheckRunEvent with cancelled, failure, timed_out or action_required
+//     conclusion
 //
 // Other events are ignored and a debug message is logged for those.
 func (a *Autoupdater) processEvent(ctx context.Context, event *github_prov.Event) {

--- a/internal/autoupdate/doc.go
+++ b/internal/autoupdate/doc.go
@@ -30,8 +30,7 @@
 // pull requests are removed from the autoupdate queue, when it was closed, or
 // an inverse trigger event (auto_merge_disabled, unlabeled) was received.
 //
-//
-// Components
+// # Components
 //
 // The main components are the queue and autoupdater.
 //

--- a/internal/autoupdate/httpservice.go
+++ b/internal/autoupdate/httpservice.go
@@ -13,6 +13,7 @@ import (
 )
 
 // templFS contains the web pages.
+//
 //go:embed pages/templates/*
 var templFS embed.FS
 

--- a/internal/autoupdate/pages/templates/list.html.tmpl
+++ b/internal/autoupdate/pages/templates/list.html.tmpl
@@ -72,7 +72,7 @@
                 <th>Rank</th>
                 <th>Pull Request</th>
                 <th>Author</th>
-                <th>Enqueued At</th>
+                <th>Ready for Updates Since</th>
                 <th>Status</th>
               </tr>
                 {{ range $i, $pr := $queue.ActivePRs }}
@@ -97,7 +97,7 @@
                     <a href="{{ $pr.Link }} ">{{ $pr.Title }} (#{{ $pr.Number }})</a>
                   </td>
                   <td>{{ $pr.Author}}</td>
-                  <td>{{ $pr.EnqueuedSince.Format "2006-01-02 15:04:05 MST" }}</td>
+                  <td></td>
                   <td class="td_status_suspended">Suspended</td>
                 </tr>
               {{ end }}

--- a/internal/autoupdate/pages/templates/list.html.tmpl
+++ b/internal/autoupdate/pages/templates/list.html.tmpl
@@ -31,7 +31,7 @@
                 disabled
               {{ end }}
               <li>
-                MonitoredRepositories:
+                Monitored Repositories:
                 <ul>
                   {{ range .MonitoredRepositories }}
                     <li>
@@ -118,23 +118,24 @@
         </header>
 
         <p>
-          The autoupdater keeps pull requests uptodate with their base branch.
+          The autoupdater keeps pull requests up to date with their base branch.
         </p>
 
         <p>
           A pull request is enqueued for autoupdates when auto_merge for the PR
-          is enabled or it is marked with a configuration label.<br>
-          The first active pull request in each queue is kept uptodate with its
-          base-branch. If the base branch changes, the base branch is merged into
-          the pull request branch.<br>
+          is enabled or it is marked with a configurable label.<br>
+          The first pull request in each queue has the active status and is kept
+          up to date with its base-branch.
+          If the base branch changes, the base branch is merged into the pull
+          request branch.<br>
           Other pull requests are enqueued for being kept uptodate.
         </p>
 
         <p>
           If a base-branch can not be merged into a pull request branch, a
           negative status check for a PR was reported, it is not approved or it
-          become stale, updates for the PR are suspended.<br>
-          When the branch of the pull request or it base branch changes or its
+          became stale, updates for the PR are suspended.<br>
+          When the branch of the pull request or its base branch changes or its
           combined check status is not negative anymore it is enqueued again for
           being kept up to date.
         </p>

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -2,7 +2,6 @@ package cfg
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/pelletier/go-toml"
 )
@@ -49,7 +48,7 @@ type Rules struct {
 func Load(reader io.Reader) (*Config, error) {
 	var result Config
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/goordinator/action/httprequest/runner.go
+++ b/internal/goordinator/action/httprequest/runner.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -44,7 +44,7 @@ func (h *Runner) Run(ctx context.Context) error {
 	}
 
 	if h.data != "" {
-		req.Body = ioutil.NopCloser(bytes.NewBufferString(h.data))
+		req.Body = io.NopCloser(bytes.NewBufferString(h.data))
 	}
 
 	req.SetBasicAuth(h.user, h.password)
@@ -59,7 +59,7 @@ func (h *Runner) Run(ctx context.Context) error {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Warn(
 			"reading http response body failed",


### PR DESCRIPTION
```
golangci-lint: remove deprecated linters

This fixes:
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

-------------------------------------------------------------------------------
godoc: reformat to go 1.19 format

Reformat the godoc to be inline with the new format introduced with go 1.19

-------------------------------------------------------------------------------
replace uses of deprecated io/ioutil package

-------------------------------------------------------------------------------
ci: update golangci-lint to version 1.49

-------------------------------------------------------------------------------
ci: update go to 1.19

-------------------------------------------------------------------------------
```