### PR TITLE
autoupdate: check if PR is first when running update operation

### DIFF
--- a/internal/autoupdate/logfields.go
+++ b/internal/autoupdate/logfields.go
@@ -9,6 +9,7 @@ import (
 var (
 	logEventUpdatesSuspended = logfields.Event("updates_suspended")
 	logEventUpdatesResumed   = logfields.Event("updates_resumed")
+	logEventUpdateSkipped    = logfields.Event("update_skipped")
 
 	logEventEnqeued      = logfields.Event("enqueued")
 	logEventDequeued     = logfields.Event("dequeued")

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -738,6 +738,7 @@ func (q *queue) updatePRWithBase(ctx context.Context, pr *PullRequest, logger *z
 
 		return false, errors.Join(updateBranchErr, err)
 	}
+
 	return changed, nil
 }
 

--- a/internal/goordinator/evloop.go
+++ b/internal/goordinator/evloop.go
@@ -83,7 +83,7 @@ func (e *EvLoop) Start() {
 
 			logger.Debug(
 				"evaluated result of matching event with rule",
-				logfields.Event("rule_match_result_evaluted"),
+				logfields.Event("rule_match_result_evaluated"),
 				zap.String("match_result", match.String()),
 			)
 


### PR DESCRIPTION
It can happen that the Update operations is run for multiple PRs instead of only
the first one in the active queue.
An example is that multiple update operations are queued in
the go-routine pool. The first run is running for PR #1, the queued one is for PR #2.
If PR #2 gets suspended, the update operation is still queued.
When a PR is suspended the update operation is only canceled if it is
also first in the queue and has been started.

To prevent it, updatePR() now checks if the PR for that it runs is the first one
in the active queue, otherwise it does nothing.
It also now checks if it's context is canceled, in the beginning, to prevent
unnecessary function calls

A better solution would be to change the go routine pool, to be able to remove
operations for the queue via the PR identifier. This would allow to always
remove updatePR operations when a PR gets suspended.