### PR TITLE
autoupdate: fix: branch update and status check failure race

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -26,7 +26,7 @@ const defPeriodicTriggerInterval = 30 * time.Minute
 // GithubClient defines the methods of a GithubAPI Client that are used by the
 // autoupdate implementation.
 type GithubClient interface {
-	UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (bool, error)
+	UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (changed bool, scheduled bool, err error)
 	CreateIssueComment(ctx context.Context, owner, repo string, issueOrPRNr int, comment string) error
 	ListPullRequests(ctx context.Context, owner, repo, state, sort, sortDirection string) githubclt.PRIterator
 	ReadyForMerge(ctx context.Context, owner, repo string, prNumber int) (*githubclt.ReadyForMergeStatus, error)

--- a/internal/autoupdate/drygithubclient.go
+++ b/internal/autoupdate/drygithubclient.go
@@ -23,9 +23,9 @@ func NewDryGithubClient(clt GithubClient, logger *zap.Logger) *DryGithubClient {
 	}
 }
 
-func (c *DryGithubClient) UpdateBranch(context.Context, string, string, int) (bool, error) {
+func (c *DryGithubClient) UpdateBranch(context.Context, string, string, int) (bool, bool, error) {
 	c.logger.Info("simulated updating of github branch, returning is uptodate")
-	return false, nil
+	return false, false, nil
 }
 
 func (c *DryGithubClient) ReadyForMerge(context.Context, string, string, int) (*githubclt.ReadyForMergeStatus, error) {

--- a/internal/autoupdate/mocks/autoupdate.go
+++ b/internal/autoupdate/mocks/autoupdate.go
@@ -85,12 +85,13 @@ func (mr *MockGithubClientMockRecorder) ReadyForMerge(ctx, owner, repo, prNumber
 }
 
 // UpdateBranch mocks base method.
-func (m *MockGithubClient) UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (bool, error) {
+func (m *MockGithubClient) UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBranch", ctx, owner, repo, pullRequestNumber)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // UpdateBranch indicates an expected call of UpdateBranch.

--- a/internal/goordinator/action/github/update_runner.go
+++ b/internal/goordinator/action/github/update_runner.go
@@ -18,13 +18,17 @@ type UpdateRunner struct {
 }
 
 func (r *UpdateRunner) Run(ctx context.Context) error {
-	changed, err := r.clt.UpdateBranch(ctx, r.repositoryOwner, r.repository, r.pullRequestNumber)
+	changed, scheduled, err := r.clt.UpdateBranch(ctx, r.repositoryOwner, r.repository, r.pullRequestNumber)
 	if err != nil {
 		return err
 	}
 
 	if changed {
-		r.logger.Info("github branch updates with base branch")
+		if scheduled {
+			r.logger.Info("updating github branch with base branch schedule scheduled")
+		} else {
+			r.logger.Info("updated github branch with base branch")
+		}
 	} else {
 		r.logger.Info("github branch already uptodate with base branch")
 	}


### PR DESCRIPTION
Sometimes multiple PRs in the autoupdater queue are updated, instead of only the first in the queue.
The operation to update a PR branch with it's base branch was not blocking. The GitHub API either returned a 200 status, when the branch update was triggered and done or 202 to indicate that it is scheduled. When it was scheduled, the update action continued and the work queue that synchronizes update operations processed the next update operations. When goordinator is also used to trigger automatically CI jobs for PRs that were updated and for that automerge is enabled, and CI jobs report a fail status when they are aborted because of an update, it also causes unnecessary CI runs.

The race works like this:
- PR#1: PR update with base is triggered, updates gets scheduled by Github
- PR#1: github updates the branch
- PR#1: CI checks fail notification for PR #1 for outdated HEAD commit is received, caused by abort of CI jobs for the outdated HEAD
- PR#2 becomes #1 in the queue, because PR#1 was suspended,  update is triggered for PR#2, causing start of CI jobs
- PR#1: Is added back to the active queue and resumed, because it's branch changed
- PR#1: CI jobs are started because the branch changed => The first and last PRs in the queue have been updated with it's base, for
   both CI jobs are running.

The race is fixed by always waiting in the Update operation until the branch has been updated. When a scheduled status is returned from GitHub, the branch status is polled periodically until it is up2date, an error is returned, or the retry timeout expired.