### PR TITLE
autoupdater: delay adding queue head label + minor improvements

### DIFF
--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -30,7 +30,7 @@ const DefStaleTimeout = 3 * time.Hour
 // blocks the first element in the queue.
 const retryTimeout = 20 * time.Minute
 
-const updateBranchPollInterval = time.Second
+const updateBranchPollInterval = 2 * time.Second
 
 // queue implements a queue for automatically updating pull request branches
 // with their base branch.

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -966,6 +966,7 @@ func (q *queue) resumeIfPRMergeStatusPositive(ctx context.Context, logger *zap.L
 
 	logger.Debug(
 		"retrieved ready-to-merge-status",
+		logfields.Commit(status.Commit),
 		logfields.ReviewDecision(string(status.ReviewDecision)),
 		logfields.CIStatusSummary(string(status.CIStatus)),
 	)

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -340,7 +340,6 @@ func (q *queue) Suspend(prNumber int) error {
 
 	if _, exist := q.suspended[prNumber]; exist {
 		q.logger.DPanic("pr was in active and suspend queue, removed it from active queue")
-		return nil
 	}
 
 	q.cancelActionForPR(prNumber)

--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -62,10 +62,9 @@ type Client struct {
 	logger     *zap.Logger
 }
 
-// BranchIsBehindBase returns true if branch is based on an old commit of baseBranch.
-// If it is based on older commit, false is returned.
-func (clt *Client) BranchIsBehindBase(ctx context.Context, owner, repo, baseBranch, branch string) (behind bool, err error) {
-	cmp, _, err := clt.restClt.Repositories.CompareCommits(ctx, owner, repo, baseBranch, branch, &github.ListOptions{PerPage: 1})
+// BranchIsBehindBase returns true if the head reference contains all changes of base.
+func (clt *Client) BranchIsBehindBase(ctx context.Context, owner, repo, base, head string) (behind bool, err error) {
+	cmp, _, err := clt.restClt.Repositories.CompareCommits(ctx, owner, repo, base, head, &github.ListOptions{PerPage: 1})
 	if err != nil {
 		return false, clt.wrapRetryableErrors(err)
 	}
@@ -121,7 +120,7 @@ func (clt *Client) PRIsUptodate(ctx context.Context, owner, repo string, pullReq
 		return false, "", errors.New("got pull request object with empty base ref field")
 	}
 
-	isBehind, err := clt.BranchIsBehindBase(ctx, owner, repo, baseBranch, prBranch)
+	isBehind, err := clt.BranchIsBehindBase(ctx, owner, repo, baseBranch, prHeadSHA)
 	if err != nil {
 		return false, "", fmt.Errorf("evaluating if branch is behind base failed: %w", err)
 	}

--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -70,7 +70,11 @@ func (clt *Client) BranchIsBehindBase(ctx context.Context, owner, repo, baseBran
 		return false, clt.wrapRetryableErrors(err)
 	}
 
-	return cmp.GetBehindBy() > 0, nil
+	if cmp.BehindBy == nil {
+		return false, goorderr.NewRetryableAnytimeError(errors.New("github returned a nil BehindBy field"))
+	}
+
+	return *cmp.BehindBy > 0, nil
 }
 
 // PullRequestIsUptodateWithBase returns true if the pull request is open and


### PR DESCRIPTION
```
autoupdate: increase updateBranchPollInterval to 2 seconds

Triggering the update branch status often returned needed to be repeated 3x
because the branch updated happened while doing the 2. retry.
Increase the interval to 2 seconds, to reduce the number of API operations by
increasing the chance that it was already updated when it is queried the second
time.

-------------------------------------------------------------------------------
autoupdate: log commit for that the ready for merge status was retrieved

This will be helpful to determine if the API returned the status for an old or
the current HEAD commit.

-------------------------------------------------------------------------------
autoupdate: delay adding queue head label

The queue head label was added as soon as an PR became first in the active
queue.
When the github event for the added label was used to trigger CI jobs this
caused unnecessary runs:
- the PR might not meet the conditions and the label is removed by the update
  operation shortly afterwards again,
- the PR might not be first anymore in the queue when the belonging update
  operation runs,´

It can also cause that a PR is wrongly suspended, in the scenario:
- label added
- update of PR branch with base branch is scheduled
- label add triggered CI job run, CI job already runs on the updated HEAD commit
  because of delays,
- synchronize branch event caused by the update with the base branch, causes
  that the same ci jobs are triggered again (unnecessarily)
- previously triggered CI jobs are canceled and a failure check event is sent to
  github
- failure check event causes the PR to be suspended

-------------------------------------------------------------------------------
githubclt: fix: UpdateBranch logs debug up2date message with old head

UpdateBranch is retrieving the HEAD sha of the PR and then checking if the PR
branch contains all changes of the base branch by specifying the PR branch name
as reference.
Between retrieving the head sha and comparing the branches, the branch might
have changed which causes that UpdateBranch was logging that the branch is
up2date with an old head commit.

Fix it by passing the PR head SHA instead of the branch name as reference when
comparing the branch with it's base.

-------------------------------------------------------------------------------
autoupdater: improve debug log messages when suspending a PR

log when suspending a PR or removing it from the active queue causes another PR
to be the first one in the queue, this can be handy when debugging issues.

-------------------------------------------------------------------------------
autoupdate: do not abort suspend procedure in unlikely error case

If a PR should be in the suspend and active queue because of a bug, continue
with the suspend procedure and overwrite the existing PR in the suspend queue.
This ensures that everything continues to work, instead of not not removing the
PR label and not aborting an update task for it.

The error scenario never happened.

-------------------------------------------------------------------------------
githubclt: return error if BehindBy field in github response is nil

This never happens but if it does, it ensures we do not return wrongly that the
PR is uptodate because GetBehindBy() returns 0 if *BehindBy is nil.

-------------------------------------------------------------------------------
```