### PR TITLE
autoupdate: fix: status of previous HEAD commit is evaluated after base branch update

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -27,7 +27,7 @@ const defPeriodicTriggerInterval = 30 * time.Minute
 // GithubClient defines the methods of a GithubAPI Client that are used by the
 // autoupdate implementation.
 type GithubClient interface {
-	UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (changed bool, scheduled bool, err error)
+	UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (*githubclt.UpdateBranchResult, error)
 	CreateIssueComment(ctx context.Context, owner, repo string, issueOrPRNr int, comment string) error
 	ListPullRequests(ctx context.Context, owner, repo, state, sort, sortDirection string) githubclt.PRIterator
 	ReadyForMerge(ctx context.Context, owner, repo string, prNumber int) (*githubclt.ReadyForMergeStatus, error)

--- a/internal/autoupdate/drygithubclient.go
+++ b/internal/autoupdate/drygithubclient.go
@@ -8,6 +8,8 @@ import (
 	"github.com/simplesurance/goordinator/internal/githubclt"
 )
 
+const headCommitID = "32d4ff96ea72412277bbfd22ff1bab3a5263b415"
+
 // DryGithubClient is a github-client that does not do any changes on github.
 // All operations that could cause a change are simulated and always succeed.
 // All all other operations are forwarded to a wrapped GithubClient.
@@ -23,9 +25,9 @@ func NewDryGithubClient(clt GithubClient, logger *zap.Logger) *DryGithubClient {
 	}
 }
 
-func (c *DryGithubClient) UpdateBranch(context.Context, string, string, int) (bool, bool, error) {
+func (c *DryGithubClient) UpdateBranch(context.Context, string, string, int) (*githubclt.UpdateBranchResult, error) {
 	c.logger.Info("simulated updating of github branch, returning is uptodate")
-	return false, false, nil
+	return &githubclt.UpdateBranchResult{HeadCommitID: headCommitID}, nil
 }
 
 func (c *DryGithubClient) ReadyForMerge(context.Context, string, string, int) (*githubclt.ReadyForMergeStatus, error) {
@@ -34,6 +36,7 @@ func (c *DryGithubClient) ReadyForMerge(context.Context, string, string, int) (*
 	return &githubclt.ReadyForMergeStatus{
 		ReviewDecision: githubclt.ReviewDecisionApproved,
 		CIStatus:       githubclt.CIStatusSuccess,
+		Commit:         headCommitID,
 	}, nil
 }
 

--- a/internal/autoupdate/mocks/autoupdate.go
+++ b/internal/autoupdate/mocks/autoupdate.go
@@ -113,13 +113,12 @@ func (mr *MockGithubClientMockRecorder) RemoveLabel(ctx, owner, repo, pullReques
 }
 
 // UpdateBranch mocks base method.
-func (m *MockGithubClient) UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (bool, bool, error) {
+func (m *MockGithubClient) UpdateBranch(ctx context.Context, owner, repo string, pullRequestNumber int) (*githubclt.UpdateBranchResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBranch", ctx, owner, repo, pullRequestNumber)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*githubclt.UpdateBranchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateBranch indicates an expected call of UpdateBranch.

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -458,6 +458,7 @@ func (q *queue) scheduleUpdate(ctx context.Context, pr *PullRequest) {
 
 		q.setExecuting(&runningTask{pr: pr.Number, cancelFunc: cancelFunc})
 		q.updatePR(ctx, pr)
+		q.setExecuting(nil)
 	})
 
 	q.logger.With(pr.LogFields...).
@@ -510,8 +511,6 @@ func (q *queue) isPRStale(pr *PullRequest) bool {
 func (q *queue) updatePR(ctx context.Context, pr *PullRequest) {
 	loggingFields := pr.LogFields
 	logger := q.logger.With(loggingFields...)
-
-	defer q.setExecuting(nil)
 
 	// q.setLastRun() is wrapped in a func to evaluate time.Now() on
 	// function exit instead of start

--- a/internal/autoupdate/queue_test.go
+++ b/internal/autoupdate/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -40,4 +41,37 @@ func TestUpdatePR_DoesNotCallBaseBranchUpdateIfPRIsNotApproved(t *testing.T) {
 	ghClient.EXPECT().UpdateBranch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	q.updatePR(context.Background(), pr)
+}
+
+func TestUpdatePRWithBaseReturnsChangedWhenScheduled(t *testing.T) {
+	t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t).Named(t.Name())))
+
+	mockctrl := gomock.NewController(t)
+	ghClient := mocks.NewMockGithubClient(mockctrl)
+
+	var updateBranchCalls int32
+	ghClient.
+		EXPECT().
+		UpdateBranch(gomock.Any(), gomock.Eq(repoOwner), gomock.Eq(repo), gomock.Any()).
+		DoAndReturn(func(context.Context, string, string, int) (*githubclt.UpdateBranchResult, error) {
+			if updateBranchCalls == 0 {
+				updateBranchCalls = updateBranchCalls + 1
+				return &githubclt.UpdateBranchResult{HeadCommitID: headCommitID, Changed: true, Scheduled: true}, nil
+			}
+			updateBranchCalls = updateBranchCalls + 1
+			return &githubclt.UpdateBranchResult{HeadCommitID: headCommitID, Changed: false, Scheduled: false}, nil
+		}).
+		Times(2)
+
+	bb, err := NewBaseBranch(repoOwner, repo, "main")
+	require.NoError(t, err)
+	q := newQueue(bb, zap.L(), ghClient, goordinator.NewRetryer(), "first")
+
+	pr, err := NewPullRequest(1, "pr_branch", "", "", "")
+	require.NoError(t, err)
+	changed, headCommit, err := q.updatePRWithBase(context.Background(), pr, zap.L(), nil)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, headCommitID, headCommit)
+	q.Stop()
 }

--- a/internal/goordinator/action/github/update_runner.go
+++ b/internal/goordinator/action/github/update_runner.go
@@ -18,13 +18,13 @@ type UpdateRunner struct {
 }
 
 func (r *UpdateRunner) Run(ctx context.Context) error {
-	changed, scheduled, err := r.clt.UpdateBranch(ctx, r.repositoryOwner, r.repository, r.pullRequestNumber)
+	result, err := r.clt.UpdateBranch(ctx, r.repositoryOwner, r.repository, r.pullRequestNumber)
 	if err != nil {
 		return err
 	}
 
-	if changed {
-		if scheduled {
+	if result.Changed {
+		if result.Scheduled {
 			r.logger.Info("updating github branch with base branch schedule scheduled")
 		} else {
 			r.logger.Info("updated github branch with base branch")

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -24,3 +24,8 @@ func (s Set[T]) Slice() []T {
 func (s Set[T]) Add(val T) {
 	s[val] = struct{}{}
 }
+
+func (s Set[T]) Contains(v T) bool {
+	_, exists := s[v]
+	return exists
+}


### PR DESCRIPTION
When a Pull-Request was updated with it's base branch by the autoupdater, the GitHub Check status of the previous HEAD commit was evaluated.
If the check status for it was negative, the PR was suspended wrongly.
This PR fixes the issue.

The autoupdater now also logs a warning message if a check status for a different commit then the current HEAD commit returned by the update operation was retrieved.
This could happen if the branch is updated between the both API operations or GitHub returned old information (which can happen).
The autoupdater is not able to handle the situation correctly.