### PR TITLE
update go & golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.62

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,27 @@
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - errcheck
-    - exportloopref
+    - errorlint
+    - gocritic
+    - gofumpt
     - goimports
-    - revive
+    - goprintffuncname
     - gosimple
+    - govet
     - ineffassign
     - misspell
+    - nosprintfhostport
     - prealloc
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
     - typecheck
     - unconvert
     - unused
-    - vet
+    - usestdlibvars
 
 linters-settings:
   goimports:

--- a/cmd/goordinator/main.go
+++ b/cmd/goordinator/main.go
@@ -203,7 +203,6 @@ func mustParseCommandlineParams() {
 	}
 
 	pflag.Parse()
-
 }
 
 func mustParseCfg() *cfg.Config {
@@ -382,7 +381,7 @@ func main() {
 
 	if *args.ShowVersion {
 		fmt.Printf("%s %s\n", appName, Version)
-		os.Exit(0)
+		os.Exit(0) // nolint:gocritic // defer functions won't run
 	}
 
 	config := mustParseCfg()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simplesurance/goordinator
 
-go 1.22.0
+go 1.23.3
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -146,7 +146,6 @@ func NewAutoupdater(
 	}
 
 	return &a
-
 }
 
 // branchRefToRef returns ref without a leading refs/heads/ prefix.
@@ -731,6 +730,7 @@ func (a *Autoupdater) processPushEvent(ctx context.Context, logger *zap.Logger, 
 
 	a.ResumeAllForBaseBranch(ctx, bb)
 }
+
 func (a *Autoupdater) processPullRequestReviewEvent(ctx context.Context, logger *zap.Logger, ev *github.PullRequestReviewEvent) {
 	owner := ev.GetRepo().GetOwner().GetLogin()
 	repo := ev.GetRepo().GetName()
@@ -1201,7 +1201,6 @@ func (a *Autoupdater) ChangeBaseBranch(
 
 	if err := a.Enqueue(ctx, newBaseBranch, pr); err != nil {
 		return fmt.Errorf("could not enqueue in queue for new base branch: %w", err)
-
 	}
 
 	return nil

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -23,12 +23,16 @@ import (
 	github_prov "github.com/simplesurance/goordinator/internal/provider/github"
 )
 
-const repo = "repo"
-const repoOwner = "testman"
-const queueHeadLabel = "first"
+const (
+	repo           = "repo"
+	repoOwner      = "testman"
+	queueHeadLabel = "first"
+)
 
-const condCheckInterval = 20 * time.Millisecond
-const condWaitTimeout = 5 * time.Second
+const (
+	condCheckInterval = 20 * time.Millisecond
+	condWaitTimeout   = 5 * time.Second
+)
 
 // mustGetActivePR fetches from the base-branch queue of the autoupdater the
 // pull request with the given pull request number.
@@ -1571,7 +1575,6 @@ func TestBaseBranchUpdatesBlockUntilFinished(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return queue.getExecuting() == nil
 	}, queue.updateBranchPollInterval+2*time.Second, queue.updateBranchPollInterval/2)
-
 }
 
 func TestPRHeadLabelIsAppliedToNextAfterMerge(t *testing.T) {

--- a/internal/autoupdate/events_test.go
+++ b/internal/autoupdate/events_test.go
@@ -22,6 +22,7 @@ func newBasicPullRequestEvent(prNumber int, branchName, baseBranchName string) *
 		},
 	}
 }
+
 func newBasicPullRequest(prNumber int, baseBranchName, branchName string) *github.PullRequest {
 	return &github.PullRequest{
 		Number: &prNumber,
@@ -71,6 +72,7 @@ func newPullRequestAutomergeEnabledEvent(prNumber int, branchName, baseBranchNam
 
 	return pr
 }
+
 func newPullRequestAutomergeDisabledEvent(prNumber int, branchName, baseBranchName string) *github.PullRequestEvent {
 	pr := newBasicPullRequestEvent(prNumber, branchName, baseBranchName)
 	pr.Action = strPtr("auto_merge_disabled")

--- a/internal/autoupdate/httpservice.go
+++ b/internal/autoupdate/httpservice.go
@@ -2,12 +2,11 @@ package autoupdate
 
 import (
 	"embed"
+	"html/template"
 	"io/fs"
 	"net/http"
 
 	_ "embed" // used to embed html templates and static docs
-
-	"html/template"
 
 	"go.uber.org/zap"
 )

--- a/internal/autoupdate/queue.go
+++ b/internal/autoupdate/queue.go
@@ -835,7 +835,8 @@ func (q *queue) prReadyForMergeStatus(ctx context.Context, pr *PullRequest) (*gi
 				logfields.Commit(status.Commit),
 				logfields.ReviewDecision(string(status.ReviewDecision)),
 				logfields.CIStatusSummary(string(status.CIStatus)),
-				zap.Any("github.ci_statuses", status.Statuses)}, loggingFields...)...,
+				zap.Any("github.ci_statuses", status.Statuses),
+			}, loggingFields...)...,
 		)
 
 		return nil
@@ -1065,8 +1066,8 @@ func (q *queue) Stop() {
 // The function returns a Set of branch names for that no PR in the queue could
 // be found.
 func (q *queue) SetPRStaleSinceIfNewerByBranch(branchNames []string, t time.Time) (
-	notFound set.Set[string]) {
-
+	notFound set.Set[string],
+) {
 	branchSet := set.From(branchNames)
 	prs, notFound := q.prsByBranch(branchSet)
 

--- a/internal/autoupdate/queue_test.go
+++ b/internal/autoupdate/queue_test.go
@@ -55,10 +55,10 @@ func TestUpdatePRWithBaseReturnsChangedWhenScheduled(t *testing.T) {
 		UpdateBranch(gomock.Any(), gomock.Eq(repoOwner), gomock.Eq(repo), gomock.Any()).
 		DoAndReturn(func(context.Context, string, string, int) (*githubclt.UpdateBranchResult, error) {
 			if updateBranchCalls == 0 {
-				updateBranchCalls = updateBranchCalls + 1
+				updateBranchCalls++
 				return &githubclt.UpdateBranchResult{HeadCommitID: headCommitID, Changed: true, Scheduled: true}, nil
 			}
-			updateBranchCalls = updateBranchCalls + 1
+			updateBranchCalls++
 			return &githubclt.UpdateBranchResult{HeadCommitID: headCommitID, Changed: false, Scheduled: false}, nil
 		}).
 		Times(2)

--- a/internal/autoupdate/routines/pool_test.go
+++ b/internal/autoupdate/routines/pool_test.go
@@ -25,7 +25,6 @@ func TestScheduleAndWait(t *testing.T) {
 	for i := range workDone {
 		assert.Equal(t, int32(1), atomic.LoadInt32(&workDone[i]), "work %d not done", i)
 	}
-
 }
 
 func TestQueuePanicsAfterWait(t *testing.T) {

--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -177,7 +177,7 @@ func (clt *Client) UpdateBranch(ctx context.Context, owner, repo string, pullReq
 
 	_, _, err = clt.restClt.PullRequests.UpdateBranch(ctx, owner, repo, pullRequestNumber, &github.PullRequestBranchUpdateOptions{ExpectedHeadSHA: &prHEADSHA})
 	if err != nil {
-		if _, ok := err.(*github.AcceptedError); ok {
+		if _, ok := err.(*github.AcceptedError); ok { // nolint:errorlint // errors.As not needed here
 			// It is not clear if the response ensures that the
 			// branch will be updated or if the scheduled operation
 			// can fail.
@@ -334,7 +334,7 @@ func (clt *Client) ListPullRequests(ctx context.Context, owner, repo, state, sor
 }
 
 func (clt *Client) wrapRetryableErrors(err error) error {
-	switch v := err.(type) {
+	switch v := err.(type) { // nolint:errorlint // errors.As not needed here
 	case *github.RateLimitError:
 		clt.logger.Info(
 			"rate limit exceeded",

--- a/internal/githubclt/client_test.go
+++ b/internal/githubclt/client_test.go
@@ -21,7 +21,7 @@ func TestWrapRetryableErrorsGraphql(t *testing.T) {
 
 	// is the same then in vendor/github.com/shurcooL/graphql/graphql.go do()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(503)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 
 	t.Cleanup(srv.Close)

--- a/internal/goordinator/action/httprequest/config.go
+++ b/internal/goordinator/action/httprequest/config.go
@@ -85,7 +85,6 @@ func NewConfigFromMap(m map[string]any) (*Config, error) {
 		data:     data,
 		logger:   zap.L().Named(loggerName),
 	}, nil
-
 }
 
 // Render runs renderFunc on all configuration options that can contain

--- a/internal/goordinator/events_test.go
+++ b/internal/goordinator/events_test.go
@@ -482,7 +482,7 @@ func newPullRequestSyncHTTPReq() *http.Request {
 	hdrs.Set("X-GitHub-Event", "pull_request")
 
 	return &http.Request{
-		Method: "POST",
+		Method: http.MethodPost,
 		Header: hdrs,
 		Body:   io.NopCloser(strings.NewReader(pullRequestSynchronizeEventPayload)),
 	}

--- a/internal/goordinator/evloop.go
+++ b/internal/goordinator/evloop.go
@@ -168,7 +168,6 @@ func (e *EvLoop) scheduleAction(ctx context.Context, event *Event, action action
 			logFieldActionResult("success"),
 		)
 	}()
-
 }
 
 // Stop stops the event loop and waits until all scheduled go-routines


### PR DESCRIPTION
```
fix or ignore issues found by golangci-lint

-------------------------------------------------------------------------------
golangci-lint: update config

replace deprecated linters, enable new ones

-------------------------------------------------------------------------------
ci: update golangci-lint to 1.62

-------------------------------------------------------------------------------
update go to 1.23.3

-------------------------------------------------------------------------------
```